### PR TITLE
Phase 1: local development stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# Local-development defaults. Copy to .env at the repo root and adjust as needed.
+#
+# Both the backend (loaded via python-dotenv in backend/biosim_server/config.py)
+# and the frontend (loaded via dotenv from frontend/nuxt.config.ts) read from
+# this file when present. Variables that don't apply to one side are ignored
+# silently.
+
+# ---------- Backend ----------
+
+# File storage backend. "local" uses ./local_cache for OMEX caching and lets
+# you run without GCS credentials. "minio" uses the S3 service from
+# `docker compose --profile minio up -d`. "gcs" is the production default.
+STORAGE_BACKEND=local
+STORAGE_LOCAL_CACHE_DIR=./local_cache
+
+# If STORAGE_BACKEND=minio, these match the compose service.
+# STORAGE_BUCKET=platform-local
+# STORAGE_ENDPOINT_URL=http://localhost:9000
+# STORAGE_ACCESS_KEY=minioadmin
+# STORAGE_SECRET_KEY=minioadmin
+
+# Infra (matches compose.yaml).
+TEMPORAL_SERVICE_URL=localhost:7233
+MONGODB_URI=mongodb://localhost:27017
+
+# External APIs. Defaults point at production biosimulations.org — the local
+# backend calls these for real simulation runs. Override only to target a
+# staging instance or a mock.
+# BIOSIMULATIONS_API_BASE_URL=https://api.biosimulations.org
+# SIMDATA_API_BASE_URL=https://simdata.api.biosimulations.org
+# BIOSIMULATORS_API_BASE_URL=https://api.biosimulators.org
+
+# ---------- Frontend ----------
+
+# The frontend's own origin (used by @nuxtjs/seo) and the platform backend URL
+# it should call from the browser.
+BASE_URL=http://localhost:4200
+API_URL=http://localhost:8000
+
+# Public biosimulations.org project DB API (different service from the platform
+# backend; used by pages/biosim-db.vue).
+BIOSIMULATIONS_API_URL=https://api.biosimulations.org

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,9 @@ worker/.worker_STABLE
 build
 .DS_Store
 
+# Local-dev artifacts
+/local_cache/
+
 
 .python-version
 

--- a/README.md
+++ b/README.md
@@ -11,22 +11,37 @@ _Production API:_ **[https://biosim.biosimulations.org/docs](https://biosim.bios
 | Directory | Purpose |
 |-----------|---------|
 | [`backend/`](./backend) | Python FastAPI + Temporal worker services. See [`backend/README.md`](./backend/README.md). |
-| [`frontend/`](./frontend) | Nuxt 4 / Nuxt UI webapp (pnpm). See [`frontend/README.md`](./frontend/README.md). |
+| [`frontend/`](./frontend) | Nuxt 4 / Nuxt UI webapp (npm). See [`frontend/README.md`](./frontend/README.md). |
 | [`kustomize/`](./kustomize) | Shared Kubernetes manifests and per-cluster overlays. |
 | `.github/workflows/` | CI pipelines. Root workflow covers backend; frontend ships its own under `frontend/.github/workflows/`. |
 
-## Quickstart
+## Local development
 
-Backend:
+Bring up the local infra (Mongo + Temporal; minio optional) and run the backend + frontend natively for fast HMR / reloads.
 
 ```bash
-cd backend
-poetry install
-poetry run uvicorn biosim_server.api.main:app --host 0.0.0.0 --port 8000
-poetry run python -m biosim_server.worker.worker_main
+# 1. Infra in containers
+scripts/dev-up.sh                 # mongo + temporal
+scripts/dev-up.sh --minio         # also bring up minio (S3-compatible storage)
+
+# 2. Backend API (terminal A)
+cd backend && poetry install
+poetry run uvicorn biosim_server.api.main:app --host 0.0.0.0 --port 8000 --reload
+
+# 3. Backend worker (terminal B)
+cd backend && poetry run python -m biosim_server.worker.worker_main
+
+# 4. Frontend dev server (terminal C)
+cd frontend && npm install && npm run dev   # http://localhost:4200
+
+# Tear down
+scripts/dev-down.sh               # stop containers, keep volumes
+scripts/dev-down.sh --wipe        # stop and delete volumes
 ```
 
-See [`backend/README.md`](./backend/README.md) and [`backend/CLAUDE.md`](./backend/CLAUDE.md) for full backend docs.
+**Config:** `dev-up.sh` copies `.env.example` → `.env` on first run. By default the backend uses `STORAGE_BACKEND=local` (filesystem cache under `./local_cache`); enable minio with `scripts/dev-up.sh --minio` and switch `STORAGE_BACKEND=minio` in `.env`. The backend calls the real public biosimulations.org APIs by default — overrideable via `BIOSIMULATIONS_API_BASE_URL` and friends.
+
+**Per-service docs:** [`backend/README.md`](./backend/README.md) + [`backend/CLAUDE.md`](./backend/CLAUDE.md); [`frontend/README.md`](./frontend/README.md) + [`frontend/CLAUDE.md`](./frontend/CLAUDE.md).
 
 ## Build & deploy
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - Platform Backend Development Guide
 
-This guide covers the backend service. For monorepo orientation (frontend, kustomize, deployment), see the root `CLAUDE.md`.
+This guide covers the backend service. For monorepo orientation (frontend, kustomize, deployment), see the root `CLAUDE.md`. For the integrated local-dev workflow (Mongo + Temporal in containers, backend + frontend native), see the **Local development** section of the root `README.md`.
 
 All commands below assume the working directory is `backend/` (i.e., `cd backend` from the repo root first).
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,50 @@
+# Local development infrastructure.
+#
+# Brings up Mongo and Temporal (always) and minio (opt-in via `--profile minio`).
+# The application code (backend api, backend worker, frontend) runs natively on
+# the developer's machine for fast HMR / fast reloads; see scripts/dev-up.sh.
+#
+#   docker compose up -d                  # mongo + temporal
+#   docker compose --profile minio up -d  # mongo + temporal + minio
+#   docker compose down                   # stop everything (keep volumes)
+#   docker compose down -v                # stop and wipe volumes
+
+services:
+  mongo:
+    image: mongo:7
+    container_name: platform-mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    restart: unless-stopped
+
+  temporal:
+    # Single-binary dev mode (in-memory SQLite, no separate Postgres, no Web UI).
+    # gRPC on 7233. If you need the workflow Web UI, swap to temporalio/auto-setup.
+    image: temporalio/temporal:1.7.0
+    container_name: platform-temporal
+    command: ["server", "start-dev", "--ip", "0.0.0.0"]
+    ports:
+      - "7233:7233"
+    restart: unless-stopped
+
+  minio:
+    # Off by default — enable with `docker compose --profile minio up -d`.
+    image: minio/minio:latest
+    container_name: platform-minio
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # web console
+    volumes:
+      - minio_data:/data
+    profiles: ["minio"]
+    restart: unless-stopped
+
+volumes:
+  mongo_data:
+  minio_data:

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - Platform Frontend Development Guide
 
-This guide covers the webapp. For monorepo orientation (backend, kustomize, deployment), see the root `CLAUDE.md`.
+This guide covers the webapp. For monorepo orientation (backend, kustomize, deployment), see the root `CLAUDE.md`. For the integrated local-dev workflow (Mongo + Temporal in containers, backend + frontend native), see the **Local development** section of the root `README.md`.
 
 All commands below assume the working directory is `frontend/` (i.e., `cd frontend` from the repo root first).
 

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Stop local-development infrastructure. Volumes are preserved by default;
+# pass --wipe to discard them too.
+#
+# Usage:
+#   scripts/dev-down.sh          # stop containers, keep mongo + minio data
+#   scripts/dev-down.sh --wipe   # also delete volumes
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Need --profile minio here too, otherwise compose won't tear down the minio
+# service if it happens to be running.
+if [[ "${1:-}" == "--wipe" ]]; then
+  docker compose --profile minio down -v
+else
+  docker compose --profile minio down
+fi

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Start local-development infrastructure (Mongo + Temporal, optionally minio).
+#
+# Usage:
+#   scripts/dev-up.sh           # mongo + temporal
+#   scripts/dev-up.sh --minio   # mongo + temporal + minio
+#
+# Backend api/worker and the frontend dev server still run natively on your
+# machine — see the commands printed below.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+PROFILE_ARGS=()
+if [[ "${1:-}" == "--minio" ]]; then
+  PROFILE_ARGS=(--profile minio)
+fi
+
+if [[ ! -f .env && -f .env.example ]]; then
+  echo "note: no .env found at repo root; copying .env.example -> .env"
+  cp .env.example .env
+fi
+
+docker compose "${PROFILE_ARGS[@]}" up -d
+
+echo
+echo "Infra is up. Next:"
+echo
+echo "  # backend api (in another terminal)"
+echo "  cd backend && poetry run uvicorn biosim_server.api.main:app --host 0.0.0.0 --port 8000 --reload"
+echo
+echo "  # backend worker (in another terminal)"
+echo "  cd backend && poetry run python -m biosim_server.worker.worker_main"
+echo
+echo "  # frontend (in another terminal)"
+echo "  cd frontend && npm run dev"
+echo
+echo "When you're done: scripts/dev-down.sh"


### PR DESCRIPTION
## Summary

Stands up an integrated local-dev workflow for the platform: containerized infra (Mongo + Temporal, minio optional) with the backend api/worker and frontend dev server running natively for fast HMR / reloads. Picks up where #39 (pre-work) left off — depends on its `STORAGE_BACKEND=local|minio` selector, runtime-config refactors, and frontend npm switch.

**Stacked on #39** (base branch: `frontend-backend-int`). Once #39 merges, GitHub will auto-retarget this PR to `main`.

## What's in here

- **`compose.yaml`** — `mongo:7` on `27017`, `temporalio/temporal:1.7.0 server start-dev` on `7233` (no Web UI), and `minio/minio` on `9000`+`9001` behind a `minio` compose profile. Named volumes for Mongo and minio.
- **`.env.example`** — sensible local defaults: `STORAGE_BACKEND=local`, infra URLs, and the three frontend runtime keys (`BASE_URL`, `API_URL`, `BIOSIMULATIONS_API_URL`).
- **`scripts/dev-up.sh`** — `docker compose up -d` (optionally `--minio`), seeds `.env` from `.env.example` on first run, prints the three native commands the developer still has to run.
- **`scripts/dev-down.sh`** — `docker compose down` (`--wipe` also removes volumes).
- **Root `README.md`** — new **Local development** section walking through the four-terminal workflow.
- **`backend/CLAUDE.md` + `frontend/CLAUDE.md`** — cross-link to the new Local development section.
- **`.gitignore`** — adds `/local_cache/` (default `STORAGE_LOCAL_CACHE_DIR`).

## What's not in here

- Phase 2 (joint deploy): `frontend/Dockerfile`, `kustomize/base/frontend/`, `build_and_push.sh` extensions, `frontend-dev` overlay.
- Phase 3 (tests): backend integration tests against the local stack and a CI smoke test.

## Test plan

- [x] `docker compose up -d` starts mongo + temporal; TCP probes to `localhost:27017` and `localhost:7233` succeed.
- [x] `docker compose --profile minio up -d` additionally starts minio; `curl http://localhost:9000/minio/health/ready` returns 200.
- [x] `docker compose down` cleans up containers and the bridge network.
- [x] `scripts/dev-up.sh` / `scripts/dev-down.sh` syntax-check (`bash -n`) and have executable bit set.
- [x] Compose file validates (`docker compose config`).
- [ ] End-to-end run of backend + frontend against this stack — recommend reviewer runs through the README Local development section once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)