### PR TITLE
Windows local-dev note + dev-up.sh bash 3.2 fix + stale path-filter line

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Production API:_ **[https://biosim.biosimulations.org/docs](https://biosim.bios
 | [`backend/`](./backend) | Python FastAPI + Temporal worker services. See [`backend/README.md`](./backend/README.md). |
 | [`frontend/`](./frontend) | Nuxt 4 / Nuxt UI webapp (npm). See [`frontend/README.md`](./frontend/README.md). |
 | [`kustomize/`](./kustomize) | Shared Kubernetes manifests and per-cluster overlays. |
-| `.github/workflows/` | CI pipelines. `ci.yaml` runs backend tests; `frontend-ci.yaml` runs frontend lint + typecheck. Both are path-filtered. |
+| `.github/workflows/` | CI pipelines. `ci.yaml` runs backend tests; `frontend-ci.yaml` runs frontend lint + typecheck; `smoke.yaml` runs the joint local-stack smoke. All three run on every PR (no path filters). |
 
 ## Local development
 
@@ -42,6 +42,15 @@ scripts/dev-down.sh --wipe        # stop and delete volumes
 **Config:** `dev-up.sh` copies `.env.example` → `.env` on first run. By default the backend uses `STORAGE_BACKEND=local` (filesystem cache under `./local_cache`); enable minio with `scripts/dev-up.sh --minio` and switch `STORAGE_BACKEND=minio` in `.env`. The backend calls the real public biosimulations.org APIs by default — overrideable via `BIOSIMULATIONS_API_BASE_URL` and friends.
 
 **Per-service docs:** [`backend/README.md`](./backend/README.md) + [`backend/CLAUDE.md`](./backend/CLAUDE.md); [`frontend/README.md`](./frontend/README.md) + [`frontend/CLAUDE.md`](./frontend/CLAUDE.md).
+
+### Windows
+
+Two supported paths — pick by how much parity you need with the rest of the team.
+
+- **Git Bash** (ships with [Git for Windows](https://git-scm.com/download/win)). Run the same `scripts/dev-up.sh` / `scripts/dev-down.sh` from Git Bash; Docker Desktop on Windows puts `docker` on `PATH` and the scripts use only Windows-side tokens, so there's no MSYS path-translation pain. Lefthook finds Git Bash automatically; the `nvm.sh` line in `lefthook.yml` no-ops and the hook falls back to whatever Node is on `PATH` (must be 22). Install Python + Poetry + Node 22 with your usual Windows installers. **One gotcha:** if `*.sh` files get checked out with CRLF endings, bash fails with `$'\r': command not found` — run `git config --global core.autocrlf input` before cloning, or convert in-place with `dos2unix scripts/*.sh`.
+- **WSL2** (Ubuntu). Strict parity with macOS/Linux teammates and with what `backend-ci`/`frontend-ci` run on `ubuntu-latest`. Worth the ~30 min setup if you'll be touching `kustomize/scripts/build_and_push.sh`, debugging hook portability, or running anything Linux-flavored. Two footguns: keep the repo inside the WSL filesystem (e.g. `~/code/platform`, not `/mnt/c/...`) for usable file-watch and I/O perf, and use Docker Desktop with the WSL2 integration enabled so `docker` inside WSL talks to the same daemon as the host.
+
+PowerShell-native scripts aren't provided — Git Bash covers the same ground without the maintenance overhead of parallel `.ps1` versions.
 
 ### Commit hooks
 

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -24,7 +24,7 @@ if [[ ! -f .env && -f .env.example ]]; then
   cp .env.example .env
 fi
 
-docker compose "${PROFILE_ARGS[@]}" up -d
+docker compose ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} up -d
 
 echo
 echo "Infra is up. Next:"


### PR DESCRIPTION
## Summary

Three small, related touch-ups bundled together:

1. **`scripts/dev-up.sh` on macOS bash 3.2.** Hit `PROFILE_ARGS[@]: unbound variable` under `set -u` when the array is empty — bash 3.2 (macOS default) treats `"${arr[@]}"` of an empty array as unbound; bash 4.4 fixed that. Switched to `${arr[@]+"${arr[@]}"}`, safe everywhere.
2. **`README.md` — new Windows subsection** in *Local development*. Documents Git Bash (works today with these scripts, no porting needed) and WSL2 (strict CI parity, recommended for full participation), with the actual gotchas each path implies. Explicitly skips PowerShell ports.
3. **`README.md` — stale "path-filtered" claim** in the layout table. PR #42 dropped path filters when cross-service refactors started slipping past them; corrected and mentioned the smoke workflow alongside.

No code/behavior changes beyond the one-line bash fix.

## Test plan

- [x] `./scripts/dev-up.sh` runs cleanly on macOS bash 3.2 (verified locally — Mongo + Temporal containers up).
- [x] `./scripts/dev-up.sh --minio` would also work (same array path, just with the profile arg populated).
- [ ] Sanity-check the Windows note on an actual Windows box if anyone's around to try it — not blocking; the content is conservative and matches how MSYS2 bash and WSL2 actually behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)