### PR TITLE
Split .env.example per service; fix the local-dev /compatibility/check 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ docker compose up -d            # mongo + temporal (add --profile minio for S3 t
 # then run backend and frontend natively (see backend/CLAUDE.md, frontend/CLAUDE.md)
 ```
 
-`compose.yaml` runs infra only; app code runs native (poetry/npm) for fast HMR. `.env.example` documents the env vars both services consume.
+`compose.yaml` runs infra only; app code runs native (poetry/npm) for fast HMR. Each service has its own `.env.example` (`backend/.env.example`, `frontend/.env.example`) — `dev-up.sh` seeds the per-service `.env` files on first run.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ scripts/dev-down.sh               # stop containers, keep volumes
 scripts/dev-down.sh --wipe        # stop and delete volumes
 ```
 
-**Config:** `dev-up.sh` copies `.env.example` → `.env` on first run. By default the backend uses `STORAGE_BACKEND=local` (filesystem cache under `./local_cache`); enable minio with `scripts/dev-up.sh --minio` and switch `STORAGE_BACKEND=minio` in `.env`. The backend calls the real public biosimulations.org APIs by default — overrideable via `BIOSIMULATIONS_API_BASE_URL` and friends.
+**Config:** each service has its own `.env`. `dev-up.sh` seeds them on first run by copying `backend/.env.example` → `backend/.env` and `frontend/.env.example` → `frontend/.env`. Backend reads via `python-dotenv` (walks up from CWD); frontend reads via Nuxt's built-in dotenv at dev-server startup. By default the backend uses `STORAGE_BACKEND=local` (filesystem cache under `./local_cache`); enable minio with `scripts/dev-up.sh --minio` and switch `STORAGE_BACKEND=minio` in `backend/.env`. The backend calls the real public biosimulations.org APIs by default — overrideable via `BIOSIMULATIONS_API_BASE_URL` and friends. The frontend's `.env` uses Nuxt's `NUXT_PUBLIC_*` runtime-override names so local dev exercises the same code path as the deployed ConfigMaps.
 
 **Per-service docs:** [`backend/README.md`](./backend/README.md) + [`backend/CLAUDE.md`](./backend/CLAUDE.md); [`frontend/README.md`](./frontend/README.md) + [`frontend/CLAUDE.md`](./frontend/CLAUDE.md).
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,11 +1,7 @@
-# Local-development defaults. Copy to .env at the repo root and adjust as needed.
-#
-# Both the backend (loaded via python-dotenv in backend/biosim_server/config.py)
-# and the frontend (loaded via dotenv from frontend/nuxt.config.ts) read from
-# this file when present. Variables that don't apply to one side are ignored
-# silently.
-
-# ---------- Backend ----------
+# Local-development defaults for the backend service.
+# Copy to backend/.env (gitignored). Loaded by python-dotenv from
+# biosim_server/config.py — `load_dotenv()` walks up from the process CWD,
+# so running `cd backend && poetry run uvicorn ...` picks this file up.
 
 # File storage backend. "local" uses ./local_cache for OMEX caching and lets
 # you run without GCS credentials. "minio" uses the S3 service from
@@ -33,15 +29,4 @@ MONGODB_URI=mongodb://localhost:27017
 # Additional CORS origins (comma-separated). Local dev usually doesn't need
 # this — the built-in list already covers localhost ports. Deployments
 # (kustomize overlays) set this to the deployed frontend host(s).
-# CORS_EXTRA_ORIGINS=https://biosim.biosimulations.org,https://biosim-dev.biosimulations.org
-
-# ---------- Frontend ----------
-
-# The frontend's own origin (used by @nuxtjs/seo) and the platform backend URL
-# it should call from the browser.
-BASE_URL=http://localhost:4200
-API_URL=http://localhost:8000
-
-# Public biosimulations.org project DB API (different service from the platform
-# backend; used by pages/biosim-db.vue).
-BIOSIMULATIONS_API_URL=https://api.biosimulations.org
+# CORS_EXTRA_ORIGINS=https://example.org,https://example-dev.org

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,17 @@
+# Local-development defaults for the Nuxt frontend.
+# Copy to frontend/.env (gitignored). Loaded automatically by Nuxt's built-in
+# dotenv at dev-server startup.
+#
+# We use NUXT_PUBLIC_<KEY> names (and NUXT_<KEY> for server-only keys) — that
+# matches how Nuxt's runtime config override works at process startup and how
+# the deployment ConfigMaps are wired (see kustomize/config/*/frontend.env),
+# so local dev exercises the same code path as prod.
+
+NUXT_PUBLIC_BASE_URL=http://localhost:4200
+NUXT_PUBLIC_API_URL=http://localhost:8000
+NUXT_PUBLIC_BIOSIMULATIONS_API_URL=https://api.biosimulations.org
+
+# Server-only: in-cluster URL Nitro uses for SSR-time fetches to the backend
+# (skips the public ingress in K8s). In local dev there's no separate
+# in-cluster API, so point this at the same host as NUXT_PUBLIC_API_URL.
+NUXT_API_URL=http://localhost:8000

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -90,20 +90,16 @@ frontend/
 
 Defined in `nuxt.config.ts` → `runtimeConfig.public`. Read in components via `useRuntimeConfig().public`.
 
-| Variable                 | Side             | Purpose |
-|--------------------------|------------------|---------|
-| `BASE_URL`               | browser + server | Public origin the app is served from (used by `@nuxtjs/seo`) |
-| `API_URL`                | browser + server | Platform backend API base URL — points at the FastAPI service in `../backend/` |
-| `API_URL_INTERNAL`       | server only      | In-cluster URL Nitro uses for SSR-time fetches to the backend (e.g., `http://api:8000`). Skips the public ingress when the frontend is deployed alongside `api`. Falls back to `API_URL` if unset. Read via `useRuntimeConfig().apiUrl` from server-side code (`import.meta.server`); not exposed to the browser. |
-| `BIOSIMULATIONS_API_URL` | browser + server | Public biosimulations.org project DB API base URL (different service from the platform backend) — used by `pages/biosim-db.vue` |
+Use Nuxt's `NUXT_PUBLIC_<KEY>` (public) and `NUXT_<KEY>` (server-only) env-var naming — those are the names Nuxt looks for at process startup to override the build-time `runtimeConfig` values. Bare names (`API_URL`, etc.) are only picked up at *build time* and are too early for a runtime-configured container image.
 
-Set via env (or a `.env` file — `dotenv` is a dependency). Example:
-```
-BASE_URL=https://biosim.biosimulations.org
-API_URL=https://api.biosim.biosimulations.org
-API_URL_INTERNAL=http://api:8000           # in-cluster only; SSR shortcut
-BIOSIMULATIONS_API_URL=https://api.biosimulations.org
-```
+| Variable                          | Side             | Purpose |
+|-----------------------------------|------------------|---------|
+| `NUXT_PUBLIC_BASE_URL`            | browser + server | Public origin the app is served from (used by `@nuxtjs/seo`) |
+| `NUXT_PUBLIC_API_URL`             | browser + server | Platform backend API base URL — points at the FastAPI service in `../backend/` |
+| `NUXT_API_URL`                    | server only      | In-cluster URL Nitro uses for SSR-time fetches to the backend (e.g., `http://api:8000`). Skips the public ingress when the frontend is deployed alongside `api`. Read via `useRuntimeConfig().apiUrl` from server-side code (`import.meta.server`); not exposed to the browser. |
+| `NUXT_PUBLIC_BIOSIMULATIONS_API_URL` | browser + server | Public biosimulations.org project DB API base URL (different service from the platform backend) — used by `pages/biosim-db.vue` |
+
+Local dev: copy `frontend/.env.example` → `frontend/.env` (or let `scripts/dev-up.sh` seed it). Loaded by Nuxt's built-in dotenv at dev-server startup. Deployed: the corresponding ConfigMap (`kustomize/config/<overlay>/frontend.env`) supplies the same names.
 
 ## Backend API Integration
 

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -19,12 +19,21 @@ if [[ "${1:-}" == "--minio" ]]; then
   PROFILE_ARGS=(--profile minio)
 fi
 
-if [[ ! -f .env && -f .env.example ]]; then
-  echo "note: no .env found at repo root; copying .env.example -> .env"
-  cp .env.example .env
-fi
+# Per-service .env files (gitignored). Backend reads via python-dotenv;
+# frontend reads via Nuxt's built-in dotenv at dev-server startup.
+seed_env() {
+  local dir="$1"
+  if [[ ! -f "${dir}/.env" && -f "${dir}/.env.example" ]]; then
+    echo "note: no ${dir}/.env found; copying ${dir}/.env.example -> ${dir}/.env"
+    cp "${dir}/.env.example" "${dir}/.env"
+  fi
+}
+seed_env backend
+seed_env frontend
 
-docker compose "${PROFILE_ARGS[@]}" up -d
+# `${arr[@]+"${arr[@]}"}` form is safe on macOS's default bash 3.2 — plain
+# `"${arr[@]}"` of an empty array errors as "unbound variable" under `set -u`.
+docker compose ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} up -d
 
 echo
 echo "Infra is up. Next:"


### PR DESCRIPTION
## Summary

The single root `.env.example` was a clever idea that turned out to be doing the wrong thing for the frontend.

- Backend and frontend env vars are 100% disjoint (`STORAGE_*`, `TEMPORAL_*`, `MONGODB_*`, `*_API_BASE_URL` for backend; `BASE_URL`, `API_URL`, `BIOSIMULATIONS_API_URL` for frontend), so "shared" was an organizational illusion.
- The file's comment claimed the frontend reads from the root `.env` — but Nuxt's built-in dotenv looks for `./frontend/.env` at dev-server startup. The frontend was silently ignoring the root `.env`, and `api_url` rendered empty in SSR HTML, so `npm run dev` + "Process File" 404'd on `/compatibility/check` (same failure pattern as the original prod bug fixed in PR #43).

This PR moves each service's `.env.example` next to the code that consumes it.

## Changes

- `backend/.env.example` ← `mv` from root, with python-dotenv's CWD-walk-up behavior described in the header. Backend keeps working without code changes.
- `frontend/.env.example` ← new. Uses Nuxt's `NUXT_PUBLIC_*` naming so local dev exercises the *same* runtime-override path the deployed ConfigMaps use (PR #43). The "worked locally, broke in prod" class of bug for these vars is no longer possible.
- `scripts/dev-up.sh` ← seeds both per-service `.env` files. Also re-applies the bash 3.2 fix from PR #44 that didn't make it onto `main` during the merge cycle (with a comment explaining the `${arr[@]+...}` idiom).
- `README.md`, `CLAUDE.md`, `frontend/CLAUDE.md` ← docs match the new layout. Frontend Runtime Config table now lists `NUXT_PUBLIC_*` names as canonical.

## Migration for existing devs

Run `scripts/dev-up.sh` once after pulling. It'll seed `backend/.env` and `frontend/.env` from the new examples if they're missing. The orphan root `.env` from before this change is harmless (gitignored, no longer read) — delete at your leisure.

## Test plan

- [x] `scripts/dev-up.sh` on macOS bash 3.2 — seeds both `.env` files cleanly, idempotent on second run.
- [x] `backend/poetry run ruff check .` clean.
- [ ] Restart `npm run dev` after pulling and confirm the "Process File" flow on `/simulations/run` no longer 404s. (Hands-on verification by Jim.)
- [ ] No prod deploy impact — the container's `frontend.env` ConfigMap remains the source of truth in K8s; this change is local-dev only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)