### PR TITLE
fix: header SSR hydration + nav-menu route bugs

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -119,34 +119,39 @@ const navigation_items = ref<NavigationMenuItem[][]>([
         {
           label: 'Describe visualizations',
           icon: 'i-lucide-bar-chart-3',
-          to: 'utilities/describe-visualizations',
+          to: '/utilities/describe-visualizations',
           class: 'cursor-pointer'
         },
         {
           label: 'BioSimulations REST API',
           icon: 'i-lucide-server',
           to: 'https://api.biosimulations.org',
+          target: '_blank',
           class: 'cursor-pointer'
         },
         {
           label: 'BioSimulators REST API',
           icon: 'i-lucide-database',
           to: 'https://api.biosimulators.org',
+          target: '_blank',
           class: 'cursor-pointer'
         },
         {
           label: 'Verification REST API (new)',
           icon: 'i-lucide-shield-check',
           to: 'https://biochecknet.biosimulations.org/docs',
+          target: '_blank',
           class: 'cursor-pointer'
         }
       ]
     },
     {
-      label: 'Learn',
+      label: 'Learn'
       // icon: 'i-lucide-book-open',
-      to: '',
-      class: 'cursor-pointer'
+      // TODO: add `to: '/learn'` (or a children: [...] submenu) once the
+      // Learn page exists. Previously had `to: ''` + `class: cursor-pointer`,
+      // which made Vue Router warn on every render and lied about being
+      // clickable.
     }
   ],
   [
@@ -187,13 +192,12 @@ onMounted(() => {
       class="w-max-[1200px] mx-auto"
     >
       <template #title>
-        <NuxtLink to="/">
-          <img
-            class="w-auto h-8 shrink-0"
-            src="/images/full_logo_color.svg"
-            alt="BioSimulatiosn Logo - Bio and Simulations are bisected by a circular icon of two arrows interwoven like a DNA molecule"
-          >
-        </NuxtLink>
+        <!-- UHeader's #title slot already wraps in a link to '/'; nesting <a> caused SSR hydration mismatch. -->
+        <img
+          class="w-auto h-8 shrink-0"
+          src="/images/full_logo_color.svg"
+          alt="BioSimulations Logo - Bio and Simulations are bisected by a circular icon of two arrows interwoven like a DNA molecule"
+        >
       </template>
 
       <!--      <UNavigationMenu class="hidden md:flex" orientation="horizontal" :items="navigation_items"></UNavigationMenu> -->


### PR DESCRIPTION
## Summary

Five focused fixes to `frontend/app/app.vue`, all visible in the browser console on `npm run dev`:

1. **Header logo: SSR hydration mismatch** (the loudest one). `<template #title>` wrapped its `<img>` in `<NuxtLink to="/">`, but Nuxt UI's `UHeader` already wraps the title slot in a link to `/`. The browser HTML parser auto-closes nested `<a>` tags, but Vue's client vdom kept them nested — so SSR-rendered DOM and client vdom disagreed on child count. Fix: drop the inner `NuxtLink`.
2. **Logo alt text typo:** `BioSimulatiosn` → `BioSimulations`.
3. **Describe Visualizations nav item:** `to: 'utilities/describe-visualizations'` was missing the leading `/`. Relative paths resolve against the current route, so from `/simulations/run` it went to `/simulations/utilities/describe-visualizations` (404).
4. **External REST-API nav items** (BioSimulations / BioSimulators / Verification): added `target: '_blank'` to match the existing GitHub item. External nav from a SPA shouldn't blow away the app state.
5. **"Learn" nav item:** removed the bogus `to: ''` and `cursor-pointer`. Empty `to:` made Vue Router warn on every render, and the cursor pretended the item was clickable when it wasn't. TODO comment left for when a real Learn page exists.

## Verification

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] Browser-side: open `npm run dev` at `http://localhost:4200/simulations/run`, inspect console — the "Hydration children mismatch on `<ULink to=/...>`" and "No match found for location with path /run" warnings should be gone. (Hands-on verification by Jim.)

## Worth noting separately

A `[Vue Router warn]: No match found for location with path "/run"` warning showed up in the original report. Couldn't find a literal `/run` reference in any source file — likely a stale `.nuxt/` cache or a one-off interactive click. If it persists after these fixes, `rm -rf frontend/.nuxt && npm run dev` should clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)