### PR TITLE
Add POST /simulations/runs listing endpoint + convergence plan

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -139,6 +139,7 @@ backend/
 |----------|--------|---------|
 | `/compatibility/check` | POST | Check OMEX archive compatibility with simulators |
 | `/simulations/run` | POST | Run simulations for an OMEX archive across selected simulators |
+| `/simulations/runs` | POST | List simulation runs (owner-scoped, paginated, sortable, filterable) |
 | `/simulations/{processing_id}` | GET | Get status of a simulation run |
 | `/verify/omex` | POST | Verify OMEX file across simulators |
 | `/verify/{workflow_id}` | GET | Get verification results |
@@ -151,6 +152,7 @@ backend/
 - **BiosimOmex** - OMEX file metadata (file_hash_md5, gcs_path)
 - **BiosimSims** - Simulation workflow runs (workflow_id, status, results)
 - **BiosimCompare** - Comparison results
+- **BiosimSimulationRuns** - User-facing run records for the `/simulations/runs` listing (one per submission × simulator; run_id, processing_id, name, simulator, email, status, timestamps)
 
 ## Key Patterns
 

--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     mongodb_collection_omex: str = "BiosimOmex"
     mongodb_collection_sims: str = "BiosimSims"
     mongodb_collection_compare: str = "BiosimCompare"
+    mongodb_collection_simulation_runs: str = "BiosimSimulationRuns"
 
     simdata_api_base_url: str = "https://simdata.api.biosimulations.org"
     biosimulators_api_base_url: str = "https://api.biosimulators.org"

--- a/backend/biosim_server/dependencies.py
+++ b/backend/biosim_server/dependencies.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from motor.motor_asyncio import AsyncIOMotorClient
 from temporalio.client import Client as TemporalClient
 
@@ -6,6 +8,11 @@ from biosim_server.biosim_runs.biosim_service import BiosimService, BiosimServic
 from biosim_server.biosim_runs.database import DatabaseService, DatabaseServiceMongo
 from biosim_server.common.storage import FileService, FileServiceGCS, FileServiceLocal, FileServiceMinio
 from biosim_server.config import get_local_cache_dir, get_settings
+
+if TYPE_CHECKING:
+    # Imported lazily at runtime (see init_standalone) to avoid an import cycle:
+    # simulations/__init__.py -> router -> dependencies.
+    from biosim_server.simulations.database import SimulationRunDatabaseService
 
 #------ file service (standalone or pytest) ------
 
@@ -42,6 +49,18 @@ def set_omex_database_service(omex_database_service: OmexDatabaseService | None)
 def get_omex_database_service() -> OmexDatabaseService | None:
     global global_omex_database_service
     return global_omex_database_service
+
+#------- simulation run database service (standalone or pytest) ------
+
+global_simulation_run_database_service: "SimulationRunDatabaseService | None" = None
+
+def set_simulation_run_database_service(service: "SimulationRunDatabaseService | None") -> None:
+    global global_simulation_run_database_service
+    global_simulation_run_database_service = service
+
+def get_simulation_run_database_service() -> "SimulationRunDatabaseService | None":
+    global global_simulation_run_database_service
+    return global_simulation_run_database_service
 
 #------- biosim service (standalone or pytest) ------
 
@@ -85,9 +104,13 @@ async def init_standalone() -> None:
     set_biosim_service(BiosimServiceRest())
     set_temporal_client(await TemporalClient.connect(settings.temporal_service_url))
 
+    # Local import avoids the simulations -> dependencies import cycle at module load.
+    from biosim_server.simulations.database import SimulationRunDatabaseServiceMongo
+
     motor_client = AsyncIOMotorClient(get_settings().mongodb_uri)
     set_database_service(DatabaseServiceMongo(db_client=motor_client))
     set_omex_database_service(OmexDatabaseServiceMongo(db_client=motor_client))
+    set_simulation_run_database_service(SimulationRunDatabaseServiceMongo(db_client=motor_client))
 
 async def shutdown_standalone() -> None:
     db_service = get_database_service()
@@ -106,3 +129,5 @@ async def shutdown_standalone() -> None:
     set_biosim_service(None)
     set_temporal_client(None)
     set_database_service(None)
+    # Shares the motor client closed via db_service above; just clear the handle.
+    set_simulation_run_database_service(None)

--- a/backend/biosim_server/simulations/__init__.py
+++ b/backend/biosim_server/simulations/__init__.py
@@ -1,12 +1,24 @@
 from biosim_server.simulations.activities import (
     submit_simulation_activity,
     poll_simulation_activity,
+    update_run_status_activity,
+)
+from biosim_server.simulations.database import (
+    SimulationRunDatabaseService,
+    SimulationRunDatabaseServiceMongo,
 )
 from biosim_server.simulations.models import (
     SimulatorSelection,
     RunSimulationRequest,
     SimulationJobStatus,
     ConglomerateStatus,
+    SimulationRun,
+    SimulationRunRecord,
+    ListSimulationRunsRequest,
+    ListSimulationRunsResponse,
+    TableFilter,
+    TablePagination,
+    TableSort,
 )
 from biosim_server.simulations.router import router as simulations_router
 from biosim_server.simulations.workflow import SimulationRunWorkflow, SimulationRunWorkflowInput
@@ -14,10 +26,20 @@ from biosim_server.simulations.workflow import SimulationRunWorkflow, Simulation
 __all__ = [
     "submit_simulation_activity",
     "poll_simulation_activity",
+    "update_run_status_activity",
+    "SimulationRunDatabaseService",
+    "SimulationRunDatabaseServiceMongo",
     "SimulatorSelection",
     "RunSimulationRequest",
     "SimulationJobStatus",
     "ConglomerateStatus",
+    "SimulationRun",
+    "SimulationRunRecord",
+    "ListSimulationRunsRequest",
+    "ListSimulationRunsResponse",
+    "TableFilter",
+    "TablePagination",
+    "TableSort",
     "simulations_router",
     "SimulationRunWorkflow",
     "SimulationRunWorkflowInput",

--- a/backend/biosim_server/simulations/activities.py
+++ b/backend/biosim_server/simulations/activities.py
@@ -21,7 +21,12 @@ from biosim_server.biosim_runs.models import (
     HDF5File,
 )
 from biosim_server.common.storage import FileService
-from biosim_server.dependencies import get_biosim_service, get_database_service, get_file_service
+from biosim_server.dependencies import (
+    get_biosim_service,
+    get_database_service,
+    get_file_service,
+    get_simulation_run_database_service,
+)
 
 
 class SubmitSimulationInput(BaseModel):
@@ -143,3 +148,28 @@ async def poll_simulation_activity(input: PollSimulationInput) -> BiosimulatorWo
     saved = await database_service.insert_biosimulator_workflow_run(sim_workflow_run=biosim_workflow_run)
     activity.logger.info(f"Saved BiosimulatorWorkflowRun _id={saved.database_id}")
     return saved
+
+
+class UpdateRunStatusInput(BaseModel):
+    run_id: str                              # the per-simulator job UUID == SimulationRunRecord.run_id
+    status: str                              # "CREATED" | "SUCCEEDED" | "FAILED"
+    biosimulations_run_id: str | None = None
+
+
+@activity.defn
+async def update_run_status_activity(input: UpdateRunStatusInput) -> None:
+    """Write a run's terminal status back to the queryable runs collection.
+
+    Degrades to a no-op when the runs database service is not configured (e.g.
+    unit tests that don't boot the full app), so it never fails the workflow."""
+    activity.logger.setLevel(logging.INFO)
+    runs_db = get_simulation_run_database_service()
+    if runs_db is None:
+        activity.logger.warning("Simulation run database service not available; skipping status update")
+        return
+    await runs_db.update_simulation_run(
+        input.run_id,
+        status=input.status,
+        biosimulations_run_id=input.biosimulations_run_id,
+    )
+    activity.logger.info(f"Updated run {input.run_id} status -> {input.status}")

--- a/backend/biosim_server/simulations/database.py
+++ b/backend/biosim_server/simulations/database.py
@@ -1,0 +1,235 @@
+"""Persistence for user-facing simulation run records.
+
+Backs ``POST /simulations/runs`` (the table listing). One record is written per
+``(submission x simulator)`` when a run is submitted; the workflow updates each
+record's status as the run reaches a terminal state.
+"""
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pymongo import ASCENDING, DESCENDING
+from pymongo.results import InsertOneResult
+from typing_extensions import override
+
+from biosim_server.config import get_settings
+from biosim_server.simulations.models import (
+    ListSimulationRunsRequest,
+    SimulationRunRecord,
+    TableSort,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maps API/table field ids onto persisted document fields. Anything not listed
+# is ignored, so callers cannot filter or sort on arbitrary internal fields.
+_FILTERABLE_FIELDS: dict[str, str] = {
+    "id": "run_id",
+    "run_id": "run_id",
+    "name": "name",
+    "simulator": "simulator",
+    "simulatorVersion": "simulator_version",
+    "simulator_version": "simulator_version",
+    "status": "status",
+    "email": "email",
+    "purpose": "purpose",
+    "createdAt": "submitted",
+    "submitted": "submitted",
+    "updated": "updated",
+    "runtime": "runtime",
+}
+
+_DATE_FIELDS = {"submitted", "updated"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_date(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    return value
+
+
+def _filter_clause(db_field: str, operator: str | None, value: Any) -> Any | None:
+    """Translate one TableFilter into a Mongo match clause for ``db_field``.
+
+    Returns ``None`` when the filter is incomplete or unsupported (skip it)."""
+    is_date = db_field in _DATE_FIELDS
+    op = operator or "contains"
+    if value is None and op != "is_any":
+        return None
+    if op in ("equal", "is"):
+        return value
+    if op == "on" and is_date:
+        start = _coerce_date(value)
+        if isinstance(start, datetime):
+            start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+            return {"$gte": start, "$lt": start + timedelta(days=1)}
+        return value
+    if op == "is_any":
+        values = value if isinstance(value, list) else [value]
+        return {"$in": values}
+    if op == "contains":
+        return {"$regex": re.escape(str(value)), "$options": "i"}
+    if op == "starts_with":
+        return {"$regex": "^" + re.escape(str(value)), "$options": "i"}
+    if op == "ends_with":
+        return {"$regex": re.escape(str(value)) + "$", "$options": "i"}
+    if op in ("less_than", "before"):
+        return {"$lt": _coerce_date(value) if is_date else value}
+    if op in ("greater_than", "after"):
+        return {"$gt": _coerce_date(value) if is_date else value}
+    return None
+
+
+def build_mongo_query(request: ListSimulationRunsRequest) -> dict[str, Any]:
+    """Build the Mongo filter for a runs listing request (owner scope + filters)."""
+    query: dict[str, Any] = {}
+    if request.type == "user" and request.user:
+        query["email"] = request.user
+    for table_filter in request.filters:
+        if not table_filter.id:
+            continue
+        db_field = _FILTERABLE_FIELDS.get(table_filter.id)
+        if db_field is None:
+            continue
+        clause = _filter_clause(db_field, table_filter.operator, table_filter.value)
+        if clause is None:
+            continue
+        existing = query.get(db_field)
+        if isinstance(existing, dict) and isinstance(clause, dict):
+            existing.update(clause)
+        else:
+            query[db_field] = clause
+    return query
+
+
+def resolve_sort(sort: TableSort | None) -> tuple[str, int]:
+    """Resolve a TableSort to a (db_field, direction) pair. Defaults to newest first."""
+    if sort and sort.id:
+        db_field = _FILTERABLE_FIELDS.get(sort.id)
+        if db_field is not None:
+            return db_field, DESCENDING if sort.direction == "desc" else ASCENDING
+    return "submitted", DESCENDING
+
+
+class SimulationRunDatabaseService(ABC):
+    @abstractmethod
+    async def insert_simulation_run(self, record: SimulationRunRecord) -> SimulationRunRecord:
+        pass
+
+    @abstractmethod
+    async def update_simulation_run(
+        self,
+        run_id: str,
+        *,
+        status: str | None = None,
+        biosimulations_run_id: str | None = None,
+        runtime: int | None = None,
+        results_size: int | None = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    async def query_simulation_runs(
+        self, request: ListSimulationRunsRequest
+    ) -> tuple[list[SimulationRunRecord], int]:
+        """Return a page of matching records and the total match count."""
+        pass
+
+    @abstractmethod
+    async def delete_all_simulation_runs(self) -> None:
+        pass
+
+    @abstractmethod
+    async def close(self) -> None:
+        pass
+
+
+class SimulationRunDatabaseServiceMongo(SimulationRunDatabaseService):
+    _db_client: AsyncIOMotorClient
+    _runs_col: AsyncIOMotorCollection
+
+    def __init__(self, db_client: AsyncIOMotorClient) -> None:
+        self._db_client = db_client
+        database = self._db_client.get_database(get_settings().mongodb_database)
+        self._runs_col = database.get_collection(get_settings().mongodb_collection_simulation_runs)
+
+    @override
+    async def insert_simulation_run(self, record: SimulationRunRecord) -> SimulationRunRecord:
+        if record.database_id is not None:
+            raise Exception("Cannot insert document that already has a database id")
+        logger.info(f"Inserting simulation run record {record.run_id} ({record.simulator})")
+        result: InsertOneResult = await self._runs_col.insert_one(record.model_dump())
+        if result.acknowledged:
+            inserted = record.model_copy(deep=True)
+            inserted.database_id = str(result.inserted_id)
+            return inserted
+        raise Exception("Insert failed")
+
+    @override
+    async def update_simulation_run(
+        self,
+        run_id: str,
+        *,
+        status: str | None = None,
+        biosimulations_run_id: str | None = None,
+        runtime: int | None = None,
+        results_size: int | None = None,
+    ) -> None:
+        updates: dict[str, Any] = {"updated": _utcnow()}
+        if status is not None:
+            updates["status"] = status
+        if biosimulations_run_id is not None:
+            updates["biosimulations_run_id"] = biosimulations_run_id
+        if runtime is not None:
+            updates["runtime"] = runtime
+        if results_size is not None:
+            updates["results_size"] = results_size
+        logger.info(f"Updating simulation run record {run_id}: {sorted(updates.keys())}")
+        await self._runs_col.update_one({"run_id": run_id}, {"$set": updates})
+
+    @override
+    async def query_simulation_runs(
+        self, request: ListSimulationRunsRequest
+    ) -> tuple[list[SimulationRunRecord], int]:
+        query = build_mongo_query(request)
+        sort_field, direction = resolve_sort(request.sort)
+        total: int = await self._runs_col.count_documents(query)
+
+        page = max(request.pagination.page, 1)
+        per_page = max(request.pagination.per_page, 1)
+        skip = (page - 1) * per_page
+
+        cursor = self._runs_col.find(query).sort(sort_field, direction).skip(skip).limit(per_page)
+        documents = await cursor.to_list(length=per_page)
+
+        records: list[SimulationRunRecord] = []
+        for doc in documents:
+            doc_dict = dict(doc)
+            doc_dict["database_id"] = str(doc["_id"])
+            del doc_dict["_id"]
+            records.append(SimulationRunRecord.model_validate(doc_dict))
+        return records, total
+
+    @override
+    async def delete_all_simulation_runs(self) -> None:
+        logger.info("Deleting all simulation run records")
+        result = await self._runs_col.delete_many({})
+        if not result.acknowledged:
+            raise Exception("Delete failed")
+
+    @override
+    async def close(self) -> None:
+        self._db_client.close()

--- a/backend/biosim_server/simulations/models.py
+++ b/backend/biosim_server/simulations/models.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SimulatorSelection(BaseModel):
@@ -27,3 +30,145 @@ class SimulationJobStatus(BaseModel):
 class ConglomerateStatus(BaseModel):
     processing_id: str                           # Temporal parent workflow ID
     jobs: list[SimulationJobStatus]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# Frontend-facing run status. Internal SimulationJobStatus.status
+# ("processing" | "success" | "failure") maps onto these.
+RunDisplayStatus = Literal["CREATED", "SUCCEEDED", "FAILED"]
+
+_JOB_TO_DISPLAY_STATUS: dict[str, RunDisplayStatus] = {
+    "processing": "CREATED",
+    "success": "SUCCEEDED",
+    "failure": "FAILED",
+}
+
+
+def job_status_to_display(job_status: str) -> RunDisplayStatus:
+    """Map an internal SimulationJobStatus.status onto the listing status."""
+    return _JOB_TO_DISPLAY_STATUS.get(job_status, "CREATED")
+
+
+class SimulationRunRecord(BaseModel):
+    """Persisted, queryable record of a single (submission x simulator) run.
+
+    One ``POST /simulations/run`` submission produces one record per selected
+    simulator. ``run_id`` is the per-simulator job UUID; ``processing_id`` is the
+    parent Temporal workflow id (used by ``GET /simulations/{processing_id}``).
+
+    Fields that the platform does not yet capture (``cpus``, ``memory``,
+    ``max_time``, ``env_vars``, ``purpose``, ``runtime``, ``project_size``,
+    ``results_size``) default to empty/zero until the submit path plumbs them.
+    """
+
+    run_id: str
+    processing_id: str
+    name: str
+    simulator: str
+    simulator_version: str
+    simulator_digest: str = ""
+    cpus: int = 0
+    memory: int = 0
+    max_time: int = 0
+    env_vars: list[str] = Field(default_factory=list)
+    purpose: str = ""
+    email: str
+    status: RunDisplayStatus = "CREATED"
+    runtime: int = 0
+    project_size: int = 0
+    results_size: int = 0
+    submitted: datetime = Field(default_factory=_utcnow)
+    updated: datetime = Field(default_factory=_utcnow)
+    biosimulations_run_id: str | None = None
+    database_id: str | None = None
+
+
+class SimulationRun(BaseModel):
+    """API representation of a run, matching the frontend ``SimulationRun``
+    interface (``frontend/app/models/simulators.ts``). Serialized with camelCase
+    aliases; FastAPI emits aliases by default (``response_model_by_alias=True``)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    simulator: str
+    simulator_version: str = Field(serialization_alias="simulatorVersion")
+    simulator_digest: str = Field(serialization_alias="simulatorDigest")
+    cpus: int
+    memory: int
+    max_time: int = Field(serialization_alias="maxTime")
+    env_vars: list[str] = Field(serialization_alias="envVars")
+    purpose: str
+    email: str
+    status: str
+    runtime: int
+    project_size: int = Field(serialization_alias="projectSize")
+    results_size: int = Field(serialization_alias="resultsSize")
+    submitted: str
+    updated: str
+
+    @classmethod
+    def from_record(cls, record: SimulationRunRecord) -> "SimulationRun":
+        return cls(
+            id=record.run_id,
+            name=record.name,
+            simulator=record.simulator,
+            simulator_version=record.simulator_version,
+            simulator_digest=record.simulator_digest,
+            cpus=record.cpus,
+            memory=record.memory,
+            max_time=record.max_time,
+            env_vars=record.env_vars,
+            purpose=record.purpose,
+            email=record.email,
+            status=record.status,
+            runtime=record.runtime,
+            project_size=record.project_size,
+            results_size=record.results_size,
+            submitted=_iso(record.submitted),
+            updated=_iso(record.updated),
+        )
+
+
+def _iso(value: datetime) -> str:
+    """ISO-8601 with a trailing ``Z`` for UTC, matching the frontend's format."""
+    text = value.isoformat()
+    return text.replace("+00:00", "Z")
+
+
+class TableSort(BaseModel):
+    id: str | None = None
+    direction: Literal["asc", "desc"] | None = None
+
+
+class TableFilter(BaseModel):
+    id: str | None = None
+    operator: str | None = None
+    value: Any = None
+
+
+class TablePagination(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    page: int = 1
+    per_page: int = Field(default=20, alias="perPage")
+    total: int | None = Field(default=None, alias="_total")
+
+
+class ListSimulationRunsRequest(BaseModel):
+    """Body of ``POST /simulations/runs`` — table query for the runs listing."""
+
+    type: Literal["all", "user"] = "all"
+    user: str | None = None
+    sort: TableSort | None = None
+    filters: list[TableFilter] = Field(default_factory=list)
+    pagination: TablePagination = Field(default_factory=TablePagination)
+
+
+class ListSimulationRunsResponse(BaseModel):
+    runs: list[SimulationRun]
+    pagination: TablePagination

--- a/backend/biosim_server/simulations/router.py
+++ b/backend/biosim_server/simulations/router.py
@@ -6,8 +6,21 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 
 from biosim_server.biosim_runs import BiosimulatorVersion
-from biosim_server.dependencies import get_temporal_client, get_biosim_service, get_omex_database_service
-from biosim_server.simulations.models import RunSimulationRequest, ConglomerateStatus, SimulationJobStatus
+from biosim_server.dependencies import (
+    get_temporal_client,
+    get_biosim_service,
+    get_omex_database_service,
+    get_simulation_run_database_service,
+)
+from biosim_server.simulations.models import (
+    RunSimulationRequest,
+    ConglomerateStatus,
+    SimulationJobStatus,
+    SimulationRunRecord,
+    ListSimulationRunsRequest,
+    ListSimulationRunsResponse,
+    SimulationRun,
+)
 from biosim_server.simulations.workflow import SimulationRunWorkflow, SimulationRunWorkflowInput
 
 logger = logging.getLogger(__name__)
@@ -75,6 +88,28 @@ async def run_simulations(request: RunSimulationRequest) -> ConglomerateStatus:
     )
     logger.info(f"Started SimulationRunWorkflow with id {workflow_id}")
 
+    # Persist a queryable run record per simulator job (status CREATED). The
+    # SimulationRunWorkflow updates these to SUCCEEDED/FAILED as the run finishes.
+    # Persistence failures must not block the run, so they are logged, not raised.
+    runs_db = get_simulation_run_database_service()
+    if runs_db is not None:
+        for job_id, sim in zip(job_ids, simulator_versions):
+            try:
+                await runs_db.insert_simulation_run(SimulationRunRecord(
+                    run_id=job_id,
+                    processing_id=workflow_id,
+                    name=request.name,
+                    simulator=sim.id,
+                    simulator_version=sim.version,
+                    simulator_digest=sim.image_digest,
+                    email=request.email_address,
+                    status="CREATED",
+                ))
+            except Exception as e:
+                logger.error(f"Failed to persist simulation run record {job_id}: {e}", exc_info=e)
+    else:
+        logger.warning("Simulation run database service not available; run not persisted for listing")
+
     # Return initial status with all jobs as "processing"
     jobs = [
         SimulationJobStatus(
@@ -86,6 +121,27 @@ async def run_simulations(request: RunSimulationRequest) -> ConglomerateStatus:
         for job_id, sim in zip(job_ids, simulator_versions)
     ]
     return ConglomerateStatus(processing_id=workflow_id, jobs=jobs)
+
+
+@router.post(
+    "/runs",
+    response_model=ListSimulationRunsResponse,
+    operation_id="list-simulation-runs",
+    summary="List simulation runs (owner-scoped, paginated, sortable, filterable)",
+)
+async def list_simulation_runs(request: ListSimulationRunsRequest) -> ListSimulationRunsResponse:
+    if request.type == "user" and not request.user:
+        raise HTTPException(status_code=400, detail="user (email) is required when type is 'user'")
+
+    runs_db = get_simulation_run_database_service()
+    if runs_db is None:
+        raise HTTPException(status_code=503, detail="Simulation run database service not available")
+
+    records, total = await runs_db.query_simulation_runs(request)
+    return ListSimulationRunsResponse(
+        runs=[SimulationRun.from_record(record) for record in records],
+        pagination=request.pagination.model_copy(update={"total": total}),
+    )
 
 
 @router.get(

--- a/backend/biosim_server/simulations/workflow.py
+++ b/backend/biosim_server/simulations/workflow.py
@@ -14,8 +14,10 @@ from biosim_server.simulations.activities import (
     submit_simulation_activity,
     PollSimulationInput,
     poll_simulation_activity,
+    UpdateRunStatusInput,
+    update_run_status_activity,
 )
-from biosim_server.simulations.models import SimulationJobStatus, ConglomerateStatus
+from biosim_server.simulations.models import SimulationJobStatus, ConglomerateStatus, job_status_to_display
 
 
 class SimulationRunWorkflowInput(BaseModel):
@@ -133,5 +135,26 @@ class SimulationRunWorkflow:
                         self.job_statuses[job_id].error = msg or f"Simulation ended with status: {status}"
                     else:
                         self.job_statuses[job_id].error = "Unknown error: no simulation run returned"
+
+        # Persist each job's terminal status to the queryable runs collection.
+        # Records were created (status CREATED) by the API at submission time;
+        # this maps run_id -> SimulationRunRecord.run_id. Failures here must not
+        # fail the run, so exceptions are swallowed.
+        update_tasks = []
+        for job_id, job in self.job_statuses.items():
+            update_tasks.append(
+                workflow.execute_activity(
+                    update_run_status_activity,
+                    args=[UpdateRunStatusInput(
+                        run_id=job_id,
+                        status=job_status_to_display(job.status),
+                        biosimulations_run_id=job.biosimulations_run_id,
+                    )],
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            )
+        if update_tasks:
+            await asyncio.gather(*update_tasks, return_exceptions=True)
 
         return self.get_status()

--- a/backend/biosim_server/worker/worker_main.py
+++ b/backend/biosim_server/worker/worker_main.py
@@ -9,7 +9,8 @@ from biosim_server.biosim_runs import get_existing_biosim_simulation_run_activit
 from biosim_server.biosim_verify.activities import generate_statistics_activity
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflow
-from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity
+from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity, \
+    update_run_status_activity
 from biosim_server.simulations.workflow import SimulationRunWorkflow
 from biosim_server.dependencies import get_temporal_client, init_standalone
 
@@ -33,7 +34,8 @@ async def main() -> None:
         task_queue="verification_tasks",
         workflows=[OmexVerifyWorkflow, OmexSimWorkflow, RunsVerifyWorkflow, SimulationRunWorkflow],
         activities=[get_existing_biosim_simulation_run_activity, submit_biosim_simulation_run_activity,
-                    generate_statistics_activity, submit_simulation_activity, poll_simulation_activity],
+                    generate_statistics_activity, submit_simulation_activity, poll_simulation_activity,
+                    update_run_status_activity],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     run_futures.append(handle.run())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,7 +12,8 @@ from tests.fixtures.database_fixtures import (  # noqa: F401
     mongo_test_database,
     mongo_test_collection,
     database_service_mongo,
-    omex_database_service_mongo
+    omex_database_service_mongo,
+    simulation_run_database_service_mongo
 )
 from tests.fixtures.gcs_fixtures import (  # noqa: F401
     file_service_gcs,

--- a/backend/tests/fixtures/database_fixtures.py
+++ b/backend/tests/fixtures/database_fixtures.py
@@ -7,8 +7,9 @@ from testcontainers.mongodb import MongoDbContainer  # type: ignore
 
 from biosim_server.biosim_runs import DatabaseServiceMongo
 from biosim_server.dependencies import set_database_service, get_database_service, set_omex_database_service, \
-    get_omex_database_service
+    get_omex_database_service, set_simulation_run_database_service, get_simulation_run_database_service
 from biosim_server.biosim_omex import OmexDatabaseServiceMongo
+from biosim_server.simulations import SimulationRunDatabaseServiceMongo
 
 MONGODB_DATABASE_NAME = "mydatabase"
 MONGODB_COLLECTION_NAME = "mycollection"
@@ -43,6 +44,10 @@ async def database_service_mongo(mongo_test_client: AsyncIOMotorClient) -> Async
 
     yield db_service
 
+    # Clean up so cached BiosimulatorWorkflowRun records don't leak across tests
+    # (the container is session-scoped). Without this, a real-network test that
+    # inserts a SUCCEEDED run gives later tests a spurious cache hit.
+    await db_service.delete_all_biosimulator_workflow_runs()
     set_database_service(old_db_service)
     # await db_service.close()  the underlying client will already be closed
 
@@ -56,4 +61,18 @@ async def omex_database_service_mongo(mongo_test_client: AsyncIOMotorClient) -> 
 
     await omex_db_service.delete_all_omex_files()
     set_omex_database_service(old_omex_db_service)
+    # await db_service.close()  the underlying client will already be closed
+
+@pytest_asyncio.fixture(scope="function")
+async def simulation_run_database_service_mongo(
+    mongo_test_client: AsyncIOMotorClient,
+) -> AsyncGenerator[SimulationRunDatabaseServiceMongo, None]:
+    runs_db_service = SimulationRunDatabaseServiceMongo(db_client=mongo_test_client)
+    old_runs_db_service = get_simulation_run_database_service()
+    set_simulation_run_database_service(runs_db_service)
+
+    yield runs_db_service
+
+    await runs_db_service.delete_all_simulation_runs()
+    set_simulation_run_database_service(old_runs_db_service)
     # await db_service.close()  the underlying client will already be closed

--- a/backend/tests/fixtures/temporal_fixtures.py
+++ b/backend/tests/fixtures/temporal_fixtures.py
@@ -11,7 +11,8 @@ from biosim_server.biosim_runs import get_existing_biosim_simulation_run_activit
 from biosim_server.biosim_verify.activities import generate_statistics_activity
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflow
-from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity
+from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity, \
+    update_run_status_activity
 from biosim_server.simulations.workflow import SimulationRunWorkflow
 from biosim_server.common.temporal import pydantic_data_converter
 from biosim_server.dependencies import get_temporal_client, set_temporal_client
@@ -50,7 +51,7 @@ async def temporal_verify_worker(temporal_client: Client) -> AsyncGenerator[Work
             workflows=[OmexVerifyWorkflow, OmexSimWorkflow, RunsVerifyWorkflow, SimulationRunWorkflow],
             activities=[generate_statistics_activity, get_existing_biosim_simulation_run_activity,
                         submit_biosim_simulation_run_activity, submit_simulation_activity,
-                        poll_simulation_activity],
+                        poll_simulation_activity, update_run_status_activity],
             debug_mode=True,
             workflow_runner=UnsandboxedWorkflowRunner()
     ) as worker:

--- a/backend/tests/integration_local/test_simulations_run.py
+++ b/backend/tests/integration_local/test_simulations_run.py
@@ -27,6 +27,7 @@ from biosim_server.biosim_runs import (
     HDF5File,
 )
 from biosim_server.common.storage import FileServiceLocal
+from biosim_server.simulations import SimulationRunDatabaseServiceMongo
 from tests.fixtures.biosim_service_mock import BiosimServiceMock
 
 
@@ -63,6 +64,7 @@ async def test_simulations_run(
     omex_test_file: Path,
     omex_database_service_mongo: OmexDatabaseServiceMongo,
     database_service_mongo: DatabaseServiceMongo,
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
     file_service_local: FileServiceLocal,
     biosim_service_mock: BiosimServiceMock,
     temporal_verify_worker: Worker,
@@ -126,3 +128,30 @@ async def test_simulations_run(
         assert job["biosimulations_run_id"] is not None
         assert job["biosimulations_run_id"].startswith("mock_")
         assert job["error"] is None
+
+        # The run should now be persisted and queryable via POST /simulations/runs,
+        # with the workflow having updated its status from CREATED to SUCCEEDED.
+        list_resp = await test_client.post(
+            "/simulations/runs",
+            json={"type": "all", "filters": [], "pagination": {"page": 1, "perPage": 20}},
+        )
+        assert list_resp.status_code == 200, list_resp.text
+        listing = list_resp.json()
+        assert listing["pagination"]["_total"] == 1
+        assert len(listing["runs"]) == 1
+        run = listing["runs"][0]
+        assert run["id"] == job["job_id"]
+        assert run["name"] == "integration-local test run"
+        assert run["simulator"] == "tellurium"
+        assert run["simulatorVersion"] == "2.2.10"
+        assert run["email"] == "test@example.com"
+        assert run["status"] == "SUCCEEDED"
+
+        # Owner-scoped query: a non-matching email returns nothing.
+        other = await test_client.post(
+            "/simulations/runs",
+            json={"type": "user", "user": "someone-else@example.com",
+                  "filters": [], "pagination": {"page": 1, "perPage": 20}},
+        )
+        assert other.status_code == 200, other.text
+        assert other.json()["pagination"]["_total"] == 0

--- a/backend/tests/simulations/test_runs_query.py
+++ b/backend/tests/simulations/test_runs_query.py
@@ -1,0 +1,225 @@
+"""Tests for the simulation runs listing: POST /simulations/runs.
+
+Covers three layers:
+  * pure query translation (build_mongo_query / resolve_sort) — no DB,
+  * the Mongo-backed SimulationRunDatabaseService — testcontainers Mongo,
+  * the FastAPI endpoint — TestClient with a mocked runs DB service.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pymongo import ASCENDING, DESCENDING
+
+from biosim_server.api.main import app
+from biosim_server.simulations import SimulationRunDatabaseServiceMongo, SimulationRunRecord
+from biosim_server.simulations.database import build_mongo_query, resolve_sort
+from biosim_server.simulations.models import (
+    ListSimulationRunsRequest,
+    TableFilter,
+    TablePagination,
+    TableSort,
+)
+
+
+def _record(
+    run_id: str,
+    *,
+    name: str = "Run",
+    simulator: str = "copasi",
+    email: str = "user@example.com",
+    status: str = "CREATED",
+    submitted: datetime | None = None,
+) -> SimulationRunRecord:
+    when = submitted or datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return SimulationRunRecord(
+        run_id=run_id,
+        processing_id=f"sim-run-{run_id}",
+        name=name,
+        simulator=simulator,
+        simulator_version="1.0.0",
+        simulator_digest="sha256:abc",
+        email=email,
+        status=status,  # type: ignore[arg-type]
+        submitted=when,
+        updated=when,
+    )
+
+
+# --------------------------- query translation ---------------------------
+
+def test_build_query_all_no_filters() -> None:
+    req = ListSimulationRunsRequest(type="all")
+    assert build_mongo_query(req) == {}
+
+
+def test_build_query_user_scope() -> None:
+    req = ListSimulationRunsRequest(type="user", user="a@b.com")
+    assert build_mongo_query(req) == {"email": "a@b.com"}
+
+
+def test_build_query_contains_filter() -> None:
+    req = ListSimulationRunsRequest(
+        filters=[TableFilter(id="simulator", operator="contains", value="cop")]
+    )
+    query = build_mongo_query(req)
+    assert query["simulator"] == {"$regex": "cop", "$options": "i"}
+
+
+def test_build_query_field_alias_and_allowlist() -> None:
+    # 'createdAt' maps onto the persisted 'submitted' field; unknown ids are dropped.
+    req = ListSimulationRunsRequest(
+        filters=[
+            TableFilter(id="createdAt", operator="after", value="2024-01-01T00:00:00Z"),
+            TableFilter(id="not_a_field", operator="equal", value="x"),
+        ]
+    )
+    query = build_mongo_query(req)
+    assert "submitted" in query
+    assert query["submitted"]["$gt"] == datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert "not_a_field" not in query
+
+
+def test_build_query_is_any() -> None:
+    req = ListSimulationRunsRequest(
+        filters=[TableFilter(id="status", operator="is_any", value=["SUCCEEDED", "FAILED"])]
+    )
+    assert build_mongo_query(req)["status"] == {"$in": ["SUCCEEDED", "FAILED"]}
+
+
+def test_resolve_sort_default_is_newest_first() -> None:
+    assert resolve_sort(None) == ("submitted", DESCENDING)
+
+
+def test_resolve_sort_explicit() -> None:
+    assert resolve_sort(TableSort(id="name", direction="asc")) == ("name", ASCENDING)
+    # createdAt aliases onto submitted
+    assert resolve_sort(TableSort(id="createdAt", direction="desc")) == ("submitted", DESCENDING)
+    # unknown field falls back to default
+    assert resolve_sort(TableSort(id="bogus", direction="asc")) == ("submitted", DESCENDING)
+
+
+# --------------------------- Mongo-backed service ---------------------------
+
+@pytest.mark.asyncio
+async def test_db_insert_and_query_all(
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
+) -> None:
+    svc = simulation_run_database_service_mongo
+    await svc.insert_simulation_run(_record("a"))
+    await svc.insert_simulation_run(_record("b"))
+
+    records, total = await svc.query_simulation_runs(ListSimulationRunsRequest(type="all"))
+    assert total == 2
+    assert {r.run_id for r in records} == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_db_update_status(
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
+) -> None:
+    svc = simulation_run_database_service_mongo
+    await svc.insert_simulation_run(_record("a", status="CREATED"))
+    await svc.update_simulation_run("a", status="SUCCEEDED", biosimulations_run_id="mock_1")
+
+    records, _ = await svc.query_simulation_runs(ListSimulationRunsRequest(type="all"))
+    assert records[0].status == "SUCCEEDED"
+    assert records[0].biosimulations_run_id == "mock_1"
+
+
+@pytest.mark.asyncio
+async def test_db_user_scope_filter(
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
+) -> None:
+    svc = simulation_run_database_service_mongo
+    await svc.insert_simulation_run(_record("a", email="me@x.com"))
+    await svc.insert_simulation_run(_record("b", email="other@x.com"))
+
+    records, total = await svc.query_simulation_runs(
+        ListSimulationRunsRequest(type="user", user="me@x.com")
+    )
+    assert total == 1
+    assert records[0].run_id == "a"
+
+
+@pytest.mark.asyncio
+async def test_db_contains_filter(
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
+) -> None:
+    svc = simulation_run_database_service_mongo
+    await svc.insert_simulation_run(_record("a", simulator="copasi"))
+    await svc.insert_simulation_run(_record("b", simulator="tellurium"))
+
+    records, total = await svc.query_simulation_runs(
+        ListSimulationRunsRequest(filters=[TableFilter(id="simulator", operator="contains", value="cop")])
+    )
+    assert total == 1
+    assert records[0].simulator == "copasi"
+
+
+@pytest.mark.asyncio
+async def test_db_sort_and_paginate(
+    simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
+) -> None:
+    svc = simulation_run_database_service_mongo
+    for i in range(5):
+        await svc.insert_simulation_run(
+            _record(f"r{i}", name=f"Run {i}",
+                    submitted=datetime(2024, 1, i + 1, tzinfo=timezone.utc))
+        )
+
+    # Newest first (default sort), first page of 2.
+    page1, total = await svc.query_simulation_runs(
+        ListSimulationRunsRequest(pagination=TablePagination(page=1, perPage=2))
+    )
+    assert total == 5
+    assert [r.run_id for r in page1] == ["r4", "r3"]
+
+    page3, _ = await svc.query_simulation_runs(
+        ListSimulationRunsRequest(pagination=TablePagination(page=3, perPage=2))
+    )
+    assert [r.run_id for r in page3] == ["r0"]
+
+
+# --------------------------- FastAPI endpoint ---------------------------
+
+def test_endpoint_user_type_requires_user() -> None:
+    client = TestClient(app)
+    resp = client.post("/simulations/runs", json={"type": "user", "filters": [],
+                                                   "pagination": {"page": 1, "perPage": 20}})
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"]
+
+
+@patch("biosim_server.simulations.router.get_simulation_run_database_service")
+def test_endpoint_service_unavailable(mock_get_runs_db: MagicMock) -> None:
+    mock_get_runs_db.return_value = None
+    client = TestClient(app)
+    resp = client.post("/simulations/runs", json={"type": "all", "filters": [],
+                                                   "pagination": {"page": 1, "perPage": 20}})
+    assert resp.status_code == 503
+
+
+@patch("biosim_server.simulations.router.get_simulation_run_database_service")
+def test_endpoint_success_shape(mock_get_runs_db: MagicMock) -> None:
+    runs_db = AsyncMock()
+    runs_db.query_simulation_runs.return_value = ([_record("a", status="SUCCEEDED")], 1)
+    mock_get_runs_db.return_value = runs_db
+
+    client = TestClient(app)
+    resp = client.post("/simulations/runs", json={"type": "all", "filters": [],
+                                                   "pagination": {"page": 1, "perPage": 20}})
+    assert resp.status_code == 200
+    body = resp.json()
+    # camelCase aliases and pagination echo with _total filled in.
+    assert body["pagination"] == {"page": 1, "perPage": 20, "_total": 1}
+    assert len(body["runs"]) == 1
+    run = body["runs"][0]
+    assert run["id"] == "a"
+    assert run["status"] == "SUCCEEDED"
+    assert run["simulatorVersion"] == "1.0.0"
+    assert run["simulatorDigest"] == "sha256:abc"
+    assert run["envVars"] == []
+    assert run["submitted"].endswith("Z")

--- a/docs/simulation-runs-api-plan.md
+++ b/docs/simulation-runs-api-plan.md
@@ -1,0 +1,71 @@
+## To-Do:
+
+### Summary:
+* Create `POST /simulations/runs` (or more semantically applicable verb given POST body's nature containing table filtration, sort, and pagination parameters) page, whose purpose is to show all or user-submitted simulations (linked via user-provided e-mail address)
+___
+
+Wishlist for aforementioned "*Create `POST /simulations/runs`*" task:
+* Distinguish between user-submitted and anonymously submitted data (auth)
+* Server-side functions:
+  * Data return (based on who owns it and whether the request specifies "show MY data" or "show ALL data"
+  * Pagination
+  * Sorting
+  * Filtering
+  * Returns data as an array of `SimulationRun` objects, as detailed below:
+```ts
+export interface SimulationRun {
+  id: string // uuid
+  name: string
+  simulator: string
+  simulatorVersion: string
+  simulatorDigest: string
+  cpus: number
+  memory: number
+  maxTime: number
+  envVars: string[]
+  purpose: string
+  email: string
+  status: string
+  runtime: number
+  projectSize: number
+  resultsSize: number
+  submitted: string
+  updated: string
+}
+```
+With the following POST body:
+```ts
+{
+    "type": fetch_user.value ? 'user' : 'all', 
+    "user": fetch_user.value ? user_email.value : undefined,
+    "sort": table_sort.value, // typeof TableSort
+    "filters": valid_filters, // typeof TableFilter[]
+    "pagination": table_pagination.value // typeof TablePagination
+}
+```
+
+Based on the following classes:
+```ts
+export interface TableSort {
+  id: string | undefined
+  direction: 'asc' | 'desc' | undefined
+}
+
+export interface TableFilter {
+  id?: string
+  operator?: 'starts_with' | 'ends_with' | 'contains' | 'less_than' | 'equal' | 'greater_than' | 'before' | 'after' | 'on' | 'is_any'
+  value?: any | any[]
+
+  _filterType?: 'text' | 'date' | 'number' | 'boolean' | 'enum'
+  _filterOptions?: any[]
+}
+
+export interface TablePagination {
+  page: number
+  perPage: number
+
+  _total?: number
+}
+```
+
+All in a new endpoint in the https://api.biosim.biosimulations.org API environment

--- a/docs/simulation-runs-api-plan.md
+++ b/docs/simulation-runs-api-plan.md
@@ -1,3 +1,15 @@
+> **Status (2026-05-29): backend implemented.** `POST /simulations/runs` is live in
+> `backend/biosim_server/simulations/` — owner-scope (`type: all|user` + `user` email),
+> pagination, sorting, and filtering, returning `{ runs: SimulationRun[], pagination: { page, perPage, _total } }`.
+> Run records are persisted (collection `BiosimSimulationRuns`) on `POST /simulations/run`
+> and updated to `SUCCEEDED`/`FAILED` by `SimulationRunWorkflow`.
+>
+> **Deferred** (no source yet — returned as zero/empty): `cpus`, `memory`, `maxTime`,
+> `envVars`, `purpose`, `runtime`, `projectSize`, `resultsSize`. Real auth is not wired —
+> owner-scoping trusts the supplied email. **Frontend follow-up:** wire
+> `frontend/app/pages/simulations/index.vue` (currently mocked) to this endpoint;
+> read `runs` / `pagination._total` from the response.
+
 ## To-Do:
 
 ### Summary:

--- a/docs/simulation-runs-convergence-plan.md
+++ b/docs/simulation-runs-convergence-plan.md
@@ -1,0 +1,217 @@
+# Simulation Runs — Convergence Plan
+
+How to converge the two parallel "run one simulation on biosimulations.org"
+implementations and unify their storage, evolving from the first-cut
+`POST /simulations/runs` feature (see `simulation-runs-api-plan.md`).
+
+## Background: what's duplicated today
+
+There are two implementations of "run one simulation on biosimulations.org and
+persist it":
+
+| | verify path (pre-existing) | run path (new) |
+|---|---|---|
+| Orchestrator | `OmexVerifyWorkflow` → N **child** `OmexSimWorkflow` | `SimulationRunWorkflow` → N inline activity-pairs |
+| Per-run unit | `submit_biosim_simulation_run_activity` (monolithic: cache-check → submit → poll → fetch HDF5 → save) | `submit_simulation_activity` + `poll_simulation_activity` (same logic, split in two) |
+| Persists | `BiosimulatorWorkflowRun` → `BiosimSims` | `BiosimulatorWorkflowRun` → `BiosimSims` (**same**) + `SimulationRunRecord` |
+| `cache_buster` | plumbed end-to-end, exposed as a `/verify/omex` query param | **hardcoded `"0"`** in the router |
+
+The poll loop, the HDF5-404-retry, the cache lookup, and the save are written
+twice and already drifting. The two paths also already share the `BiosimSims`
+cache by `(file_hash, image_digest, cache_buster)` — an accidental coupling that
+should be made intentional.
+
+The records relate as a clean **many-submissions-to-one-computation**:
+`BiosimulatorWorkflowRun` is the dedup'd computation + artifacts; a submission is
+one per user action (carries `email`, user-chosen `name`, `purpose`, timestamps,
+display status) and survives cache hits. Two entities is correct; the smell in
+the first cut is that `SimulationRunRecord` *denormalized the computation columns*
+(simulator digest, cpus, sizes, runtime, …) onto every submission row.
+
+## Invariants (hold across every PR)
+
+- **The `SimulationRun` API DTO shape is frozen** — it is the frontend contract
+  (`frontend/app/models/simulators.ts`). Every PR keeps the JSON identical. A
+  golden-response regression test is added in PR0 and kept green throughout.
+- **The verify path (`/verify/omex`, `/verify/runs`) must stay green** — the
+  production risk surface, touched only by PR2. `tests/biosim_verify/` is the net.
+- **No prod data in `BiosimSimulationRuns`** — the runs-api work is not yet
+  merged/deployed, so PR3's schema change needs **no backfill**. If that stops
+  being true before PR3, add a migration.
+- Each PR passes the full `poetry run pytest -m "not integration"` gate.
+
+## Recommended ship order
+
+The safest independently-shippable order is not strictly 1→2→3:
+
+```
+PR0  (#3)   re-expose cache_buster            — trivial, isolated
+PR1  (#2a)  enrich BiosimSimulationRun parse  — additive, benefits both paths
+PR2  (#1)   Temporal convergence              — internal refactor, riskiest
+PR3  (#2b)  normalize + join-backed listing   — schema/listing, depends on PR1
+```
+
+`cache_buster` is trivial and isolated; the "deferred fields" only become real
+once parsed upstream (prerequisite to the join paying off); the Temporal refactor
+lands before the DB normalization so submission rows get their FK early.
+
+---
+
+## PR0 — Re-expose `cache_buster` on `/simulations/run` (#3)
+
+**Goal:** restore the salt capability the verify path already has (`api/main.py`
+exposes it as a query param; the run router hardcodes `"0"` at `router.py`).
+
+**Changes**
+- `simulations/models.py`: `RunSimulationRequest` gains `cache_buster: str | None = None`.
+- `router.run_simulations`: `cache_buster=request.cache_buster or "0"` → into
+  `SimulationRunWorkflowInput.cache_buster`. Default `"0"` preserves dedup.
+- Persist `cache_buster` onto `SimulationRunRecord` (helps reconstruct the cache
+  key for PR3's identity story).
+
+**Ship/test gate:** endpoint test asserting an explicit `cache_buster` reaches
+`start_workflow` args (mock the temporal client) and omitting it defaults to
+`"0"`. Document the param in the endpoint summary + `backend/CLAUDE.md`.
+
+**Depends on:** nothing. **Risk:** trivial.
+
+**Product decision to surface:** with dedup default, two submissions of the same
+OMEX+simulator share one biosimulations run id — fine for "my runs," but the UI
+should expect it. For guaranteed-distinct runs, the UI passes a unique salt
+(e.g. the `processing_id`).
+
+---
+
+## PR1 — Enrich `BiosimSimulationRun` parsing (#2a)
+
+**Goal:** actually *source* the "deferred" fields. They are the commented-out
+block on `BiosimSimulationRun` (`biosim_runs/models.py`) and biosimulations.org's
+`/runs/{id}` almost certainly returns them — but `get_sim_run` / `run_biosim_sim`
+(`biosim_service.py`) drop everything except `id/name/simulator_version/status`.
+
+**Changes**
+- **First task: confirm the wire shape.** Capture one real `/runs/{id}` response,
+  save as a fixture in `tests/fixtures/data/`. De-risks field-name guesses
+  (`cpus`, `memory`, `maxTime`, `envVars`, `purpose`, `projectSize`,
+  `resultsSize`, `runtime`, `submitted`, `updated`, `email`).
+- `biosim_runs/models.py`: uncomment those fields on `BiosimSimulationRun` as
+  `Optional` with defaults (existing stored docs still validate).
+- `biosim_service.py`: parse them with `res.get(...)` (robust to API variation)
+  in both `get_sim_run` and `run_biosim_sim`.
+
+**Ship/test gate:** unit test parsing the captured fixture → fields populate; all
+existing tests still pass (additive/optional). Verify path and cache records
+immediately carry richer data.
+
+**Depends on:** nothing. **Risk:** low (additive). Without this, PR3's join would
+surface zeros — hence it precedes PR3.
+
+---
+
+## PR2 — Temporal convergence: one reusable per-run unit (#1)
+
+**Goal:** make `OmexSimWorkflow` the single "track one biosimulations.org run"
+child workflow; delete `simulations/activities.py`'s duplicate
+`submit_simulation_activity` + `poll_simulation_activity`.
+
+**Changes**
+1. **Canonicalize the submit/poll split in `biosim_runs/activities.py`.** Split
+   the monolithic `submit_biosim_simulation_run_activity` into `submit` (returns
+   `run_id`, owns the cache-check) and `poll` (poll → HDF5 → save
+   `BiosimulatorWorkflowRun`) — mirroring what the simulations pair already does.
+2. **`OmexSimWorkflow` surfaces `run_id` early.** Refactor `OmexSimWorkflow.run`
+   to call submit → store `biosimulations_run_id` in `sim_output` → call poll.
+   Its existing `@workflow.query` then exposes the run_id *before* completion —
+   the exact capability the run endpoint needed (and the only reason it didn't
+   reuse `OmexSimWorkflow`).
+3. **`SimulationRunWorkflow` delegates to children.** Rewrite `workflow.py:run`
+   to `start_child_workflow(OmexSimWorkflow, ...)` ×N — the pattern
+   `OmexVerifyWorkflow` already uses. Parent keeps its own `job_statuses` (so the
+   existing `get_status` → `ConglomerateStatus` query is unchanged), updating from
+   child queries (early run_id) and child results (final status).
+4. **`update_run_status_activity` stays in the simulations module** — it writes
+   the *submission* record (a listing concern); the child workflow stays generic.
+5. Drop the deleted activities from `worker_main.py` and `temporal_fixtures.py`;
+   register the new biosim_runs submit/poll pair.
+
+**API contract:** unchanged.
+
+**Ship/test gate:**
+- New `OmexSimWorkflow` test: with a mock that stays `RUNNING` briefly, assert
+  `run_id` is queryable mid-run (proves early surfacing).
+- `tests/biosim_verify/test_omex_verify_workflows.py` green (verify path intact).
+- `integration_local/test_simulations_run.py` green (now via children) +
+  run-endpoint unit tests unchanged.
+
+**Depends on:** nothing functionally; recommend after PR0/PR1. **Risk:** highest
+(touches the verify prod path) → land with full verify coverage.
+**De-risk option:** add the split activities additively, migrate
+`OmexSimWorkflow`, then delete the monolithic + simulations pair in a follow-up
+commit for a smaller diff.
+
+---
+
+## PR3 — Normalize `SimulationRunRecord` + join-backed listing (#2b)
+
+**Goal:** the submission row holds identity/lifecycle + a `biosimulations_run_id`
+FK; the listing joins to `BiosimulatorWorkflowRun` for computed fields.
+
+**Changes**
+1. **Slim `SimulationRunRecord`** to submission-owned fields: `run_id,
+   processing_id, name (user label), email, purpose, status, submitted, updated,
+   cache_buster, biosimulations_run_id (FK)` — **plus `simulator` +
+   `simulator_version`** (requested identity, needed for mid-flight rows before
+   any computation exists). **Drop** the duplicated/computed columns:
+   `simulator_digest, cpus, memory, max_time, env_vars, project_size,
+   results_size, runtime`.
+2. **Indexes:** unique on `run_id`; non-unique on `biosimulations_run_id`; and an
+   index on `BiosimSims."biosim_run.id"` to back the existing
+   `get_biosimulator_workflow_runs_by_biosim_runid` lookup.
+3. **App-side join in `query_simulation_runs`:** filter/sort/paginate submissions
+   → collect the page's `biosimulations_run_id`s → batch-fetch computations
+   (`$in`) → stitch. (Prefer app-side join over `$lookup` — matches the codebase
+   style, trivially testable, one extra round trip per page.)
+4. **`SimulationRun.from_record` → `from_submission_and_computation(submission,
+   computation | None)`** — assembles the *same* DTO; computed fields default to
+   `0/[]` when `computation is None` (mid-flight). DTO shape unchanged.
+
+**The crux tradeoff:** once computed fields leave the submission collection, you
+cannot server-side filter/sort on them in a single query. **But the frontend's
+actual sort/filter columns are all submission-owned** — `index.vue` columns are
+`id, name, status, simulator, submitted`, and its `TableFilter.id` is only
+`'createdAt' | 'simulator'`. So normalization fully supports today's UI with zero
+functional loss. If a future requirement needs filtering on `runtime` /
+`projectSize`, *then* reach for `$lookup` aggregation or selectively denormalize
+those columns — don't pay that cost preemptively.
+
+**Ship/test gate:**
+- DB tests: query returns submission fields; join populates computed fields when a
+  matching `BiosimulatorWorkflowRun` exists; mid-flight (no computation) →
+  computed defaults, status from submission.
+- Golden DTO regression test from PR0 still passes.
+- `integration_local`: after completion, listing shows `SUCCEEDED` + *real*
+  digest/sizes from the join (visible because PR1 parsed them).
+
+**Depends on:** PR1 (else joined fields are empty); benefits from PR2 (early
+run_id → mid-flight rows get their FK immediately). **Risk:** medium (schema +
+listing rewrite), but no prod data to migrate.
+
+---
+
+## Net effect
+
+One per-run Temporal unit (`OmexSimWorkflow`) composed by both
+`OmexVerifyWorkflow` and `SimulationRunWorkflow`; one storage representation of a
+biosimulations.org run + artifacts (`BiosimulatorWorkflowRun`); a thin submission
+ledger that FKs into it; and `cache_buster` controllable per submission again.
+
+## Notes on MongoDB references
+
+MongoDB has no foreign-key *constraint* — `biosimulations_run_id` is a plain
+manual reference, enforced only by application code. No existence check, no
+cascade. The orphan case (a submission with no completed computation yet) is the
+**mid-flight state**, not a bug: an app-side left-join yields `null` computed
+fields → the row renders as "still running." A unique index on the computation
+side makes the join target well-defined; any hard "referenced run must exist"
+guarantee is an application check (optionally inside a transaction), never a
+schema constraint.


### PR DESCRIPTION
## Summary

Implements the simulation-runs listing endpoint (backend, full persist + query) from `docs/simulation-runs-api-plan.md`, and adds a sequenced plan for converging the duplicate run-execution paths.

### `POST /simulations/runs` (new)
- **Persistence** — `SimulationRunRecord` in a new `BiosimSimulationRuns` collection, written one-per-(submission × simulator) on `POST /simulations/run` at `status=CREATED`, then updated to `SUCCEEDED`/`FAILED` by `SimulationRunWorkflow` via a new `update_run_status_activity`. Internal `processing/success/failure` maps to the frontend's `CREATED/SUCCEEDED/FAILED`.
- **Query** — owner-scope (`type: all|user` + `user` email), pagination, sorting, filtering. Returns `{ runs: SimulationRun[], pagination: { page, perPage, _total } }`. Filter `id`s are allowlisted (also blocks arbitrary-field injection).
- **Plumbing** — `SimulationRunDatabaseService` (+ Mongo impl); DI getter wired via a lazy import to avoid the `simulations → dependencies` import cycle; new activity registered in `worker_main.py` and the test worker fixture.

### Test-isolation fix
The shared `database_service_mongo` fixture never cleaned `BiosimSims` on teardown, so the real-network `test_sim_workflow` leaked a `SUCCEEDED` record that gave later tests a spurious cache hit (failing `integration_local` in the full suite). It now cleans up on teardown, matching its sibling `omex_database_service_mongo`.

### Convergence plan (`docs/simulation-runs-convergence-plan.md`)
There are currently **two** implementations of "run one sim on biosimulations.org" (the verify path's `OmexSimWorkflow` + monolithic activity, and this path's split submit/poll activities). The doc lays out four independently-shippable PRs to converge them: re-expose `cache_buster`, enrich `BiosimSimulationRun` parsing, reuse `OmexSimWorkflow` as the single per-run unit, and normalize `SimulationRunRecord` to FK into `BiosimulatorWorkflowRun` with a join-backed listing.

## Known limitations (documented)
- Deferred fields (`cpus, memory, maxTime, envVars, purpose, runtime, projectSize, resultsSize`) default to `0`/`[]` — the platform doesn't capture them yet (PR1 in the convergence plan sources them).
- No real auth — owner-scoping trusts the supplied email.
- **Frontend follow-up:** wire `frontend/app/pages/simulations/index.vue` (currently on mock data) to this endpoint.

## Testing
- `ruff` clean; `mypy --strict` clean (`biosim_server` + `tests`).
- New `tests/simulations/test_runs_query.py` (query-translation unit tests, Mongo-backed service tests, endpoint tests) + end-to-end assertions in `tests/integration_local/test_simulations_run.py` — all pass.
- Full `poetry run pytest -m "not integration"`: **74 passed, 1 failed**. The single failure is the pre-existing `test_slurm_service` (`UnboundLocalError`, needs SSH creds) — environmental, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)