### PR TITLE
Re-expose cache_buster on POST /simulations/run (convergence PR0)

### DIFF
--- a/backend/biosim_server/simulations/models.py
+++ b/backend/biosim_server/simulations/models.py
@@ -16,6 +16,14 @@ class RunSimulationRequest(BaseModel):
     is_commercial: bool = False
     email_address: str
     newsletter_consent: bool = False
+    cache_buster: str | None = Field(
+        default=None,
+        description=(
+            "Optional salt for the (omex, simulator, cache_buster) result cache. "
+            "Omit (or null) to reuse cached results for identical submissions; pass "
+            "a unique value to force fresh biosimulations.org runs."
+        ),
+    )
 
 
 class SimulationJobStatus(BaseModel):
@@ -70,6 +78,7 @@ class SimulationRunRecord(BaseModel):
     simulator: str
     simulator_version: str
     simulator_digest: str = ""
+    cache_buster: str = "0"  # salt used for this run's result-cache key
     cpus: int = 0
     memory: int = 0
     max_time: int = 0

--- a/backend/biosim_server/simulations/router.py
+++ b/backend/biosim_server/simulations/router.py
@@ -68,11 +68,15 @@ async def run_simulations(request: RunSimulationRequest) -> ConglomerateStatus:
     job_ids = [uuid.uuid4().hex for _ in simulator_versions]
     workflow_id = f"sim-run-{uuid.uuid4()}"
 
+    # Default "0" reuses cached results across identical submissions; a caller-supplied
+    # salt forces fresh biosimulations.org runs (parity with /verify/omex's cache_buster).
+    cache_buster = request.cache_buster or "0"
+
     workflow_input = SimulationRunWorkflowInput(
         omex_file=omex_file,
         simulators=simulator_versions,
         job_ids=job_ids,
-        cache_buster="0",
+        cache_buster=cache_buster,
     )
 
     # Start Temporal workflow
@@ -102,6 +106,7 @@ async def run_simulations(request: RunSimulationRequest) -> ConglomerateStatus:
                     simulator=sim.id,
                     simulator_version=sim.version,
                     simulator_digest=sim.image_digest,
+                    cache_buster=cache_buster,
                     email=request.email_address,
                     status="CREATED",
                 ))

--- a/backend/tests/simulations/test_router.py
+++ b/backend/tests/simulations/test_router.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from biosim_server.api.main import app
 from biosim_server.biosim_omex.models import OmexFile
 from biosim_server.biosim_runs import BiosimulatorVersion
+from biosim_server.simulations.workflow import SimulationRunWorkflowInput
 
 
 MOCK_OMEX_FILE = OmexFile(
@@ -126,6 +127,66 @@ def test_run_simulations_multiple_simulators(
     assert data["jobs"][1]["simulator_id"] == "tellurium"
     # Each job has a unique ID
     assert data["jobs"][0]["job_id"] != data["jobs"][1]["job_id"]
+
+
+def _workflow_input_from(temporal_client: AsyncMock) -> SimulationRunWorkflowInput:
+    """Pull the SimulationRunWorkflowInput passed to start_workflow(args=[...])."""
+    workflow_input: SimulationRunWorkflowInput = temporal_client.start_workflow.call_args.kwargs["args"][0]
+    return workflow_input
+
+
+@patch("biosim_server.simulations.router.get_temporal_client")
+@patch("biosim_server.simulations.router.get_biosim_service")
+@patch("biosim_server.simulations.router.get_omex_database_service")
+def test_run_simulations_cache_buster_passthrough(
+    mock_get_omex_db: MagicMock,
+    mock_get_biosim: MagicMock,
+    mock_get_temporal: MagicMock,
+) -> None:
+    """An explicit cache_buster is forwarded to the workflow input."""
+    omex_db = AsyncMock()
+    omex_db.get_omex_file.return_value = MOCK_OMEX_FILE
+    mock_get_omex_db.return_value = omex_db
+
+    biosim_service = AsyncMock()
+    biosim_service.get_simulator_versions.return_value = MOCK_SIMULATOR_VERSIONS
+    mock_get_biosim.return_value = biosim_service
+
+    temporal_client = AsyncMock()
+    mock_get_temporal.return_value = temporal_client
+
+    request = _make_request()
+    request["cache_buster"] = "salt-123"
+    response = TestClient(app).post("/simulations/run", json=request)
+
+    assert response.status_code == 200
+    assert _workflow_input_from(temporal_client).cache_buster == "salt-123"
+
+
+@patch("biosim_server.simulations.router.get_temporal_client")
+@patch("biosim_server.simulations.router.get_biosim_service")
+@patch("biosim_server.simulations.router.get_omex_database_service")
+def test_run_simulations_cache_buster_defaults_to_zero(
+    mock_get_omex_db: MagicMock,
+    mock_get_biosim: MagicMock,
+    mock_get_temporal: MagicMock,
+) -> None:
+    """When cache_buster is omitted, the workflow input defaults to "0" (dedup)."""
+    omex_db = AsyncMock()
+    omex_db.get_omex_file.return_value = MOCK_OMEX_FILE
+    mock_get_omex_db.return_value = omex_db
+
+    biosim_service = AsyncMock()
+    biosim_service.get_simulator_versions.return_value = MOCK_SIMULATOR_VERSIONS
+    mock_get_biosim.return_value = biosim_service
+
+    temporal_client = AsyncMock()
+    mock_get_temporal.return_value = temporal_client
+
+    response = TestClient(app).post("/simulations/run", json=_make_request())
+
+    assert response.status_code == 200
+    assert _workflow_input_from(temporal_client).cache_buster == "0"
 
 
 @patch("biosim_server.simulations.router.get_omex_database_service")

--- a/backend/tests/simulations/test_runs_query.py
+++ b/backend/tests/simulations/test_runs_query.py
@@ -31,6 +31,7 @@ def _record(
     simulator: str = "copasi",
     email: str = "user@example.com",
     status: str = "CREATED",
+    cache_buster: str = "0",
     submitted: datetime | None = None,
 ) -> SimulationRunRecord:
     when = submitted or datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -41,6 +42,7 @@ def _record(
         simulator=simulator,
         simulator_version="1.0.0",
         simulator_digest="sha256:abc",
+        cache_buster=cache_buster,
         email=email,
         status=status,  # type: ignore[arg-type]
         submitted=when,
@@ -108,12 +110,16 @@ async def test_db_insert_and_query_all(
     simulation_run_database_service_mongo: SimulationRunDatabaseServiceMongo,
 ) -> None:
     svc = simulation_run_database_service_mongo
-    await svc.insert_simulation_run(_record("a"))
+    await svc.insert_simulation_run(_record("a", cache_buster="salt-123"))
     await svc.insert_simulation_run(_record("b"))
 
     records, total = await svc.query_simulation_runs(ListSimulationRunsRequest(type="all"))
     assert total == 2
     assert {r.run_id for r in records} == {"a", "b"}
+    # cache_buster round-trips through Mongo
+    by_id = {r.run_id: r for r in records}
+    assert by_id["a"].cache_buster == "salt-123"
+    assert by_id["b"].cache_buster == "0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**PR0** of `docs/simulation-runs-convergence-plan.md`.

## Summary
`POST /simulations/run` hardcoded `cache_buster="0"`, silently forcing result-cache dedup across all submissions. `/verify/omex` already exposes a `cache_buster` salt; this restores parity for the run endpoint.

- `RunSimulationRequest.cache_buster` (optional, documented in OpenAPI). The router resolves `request.cache_buster or "0"` and forwards it to the workflow input **and** persists it on `SimulationRunRecord`.
- **Default `"0"` preserves today's dedup behavior**; a caller-supplied salt (e.g. the `processing_id`) forces fresh biosimulations.org runs. Trade-off: with dedup, two identical submissions share one biosimulations run id — the UI should expect that.

## Testing
- `ruff` + `mypy --strict` clean.
- New endpoint tests: an explicit salt is forwarded to the workflow input; omitting it defaults to `"0"`. Plus a Mongo round-trip assertion for the persisted `cache_buster`.
- `integration_local/test_simulations_run.py` green.

## Stacking
Depends on #48's `SimulationRunRecord`, so this is **based on `feature/runs-api`**, not `main`. After #48 merges, retarget the base to `main` (the diff is just these 4 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)