### PR TITLE
Enrich BiosimSimulationRun with biosimulations.org run metadata (convergence PR1)

### DIFF
--- a/backend/biosim_server/biosim_runs/biosim_service.py
+++ b/backend/biosim_server/biosim_runs/biosim_service.py
@@ -2,7 +2,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 import aiofiles
 import aiohttp
@@ -16,6 +16,31 @@ from biosim_server.config import get_settings
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+def _sim_run_from_response(res: dict[str, Any], simulator_version: BiosimulatorVersion) -> BiosimSimulationRun:
+    """Build a BiosimSimulationRun from a biosimulations.org /runs/{id} response.
+
+    Run metadata (cpus/memory/maxTime/...) is populated when present; older or
+    in-flight runs may omit some fields, hence the .get() defaults. See
+    tests/fixtures/local_data/biosim_run_response.json for a sample payload."""
+    return BiosimSimulationRun(
+        id=res["id"],
+        name=res["name"],
+        simulator_version=simulator_version,
+        status=BiosimSimulationRunStatus(res["status"]),
+        cpus=res.get("cpus"),
+        memory=res.get("memory"),
+        max_time=res.get("maxTime"),
+        env_vars=res.get("envVars"),
+        purpose=res.get("purpose"),
+        submitted=res.get("submitted"),
+        updated=res.get("updated"),
+        project_size=res.get("projectSize"),
+        results_size=res.get("resultsSize"),
+        runtime=res.get("runtime"),
+        email=res.get("email"),
+    )
 
 
 class BiosimService(ABC):
@@ -65,9 +90,8 @@ class BiosimServiceRest(BiosimService):
         sim_id: str = res['simulator']
         sim_ver: str = res['simulatorVersion']
         sim_digest: str = res['simulatorDigest']
-        sim_status = BiosimSimulationRunStatus(res['status'])
         simulator_version = await self._get_simulator_version(sim_id=sim_id, sim_ver=sim_ver, sim_digest=sim_digest)
-        sim_run = BiosimSimulationRun(id=res["id"], name=res["name"], simulator_version=simulator_version, status=sim_status)
+        sim_run = _sim_run_from_response(res, simulator_version)
         return sim_run
 
 
@@ -98,9 +122,8 @@ class BiosimServiceRest(BiosimService):
         assert simulator_version.id == sim_id
         assert simulator_version.image_digest == sim_digest
 
-        sim_status = BiosimSimulationRunStatus(res['status'])
         simulator_version = await self._get_simulator_version(sim_id=sim_id, sim_ver=sim_ver, sim_digest=sim_digest)
-        sim_run = BiosimSimulationRun(id=res["id"], name=res["name"], simulator_version=simulator_version, status=sim_status)
+        sim_run = _sim_run_from_response(res, simulator_version)
 
         # logger.info("Submitted " + omex_name + " on biosimulations with simulation id: " + sim_run.id)
         # logger.info("View:", api_base_url + "/runs/" + sim_run.id)

--- a/backend/biosim_server/biosim_runs/models.py
+++ b/backend/biosim_server/biosim_runs/models.py
@@ -84,17 +84,21 @@ class BiosimSimulationRun(BaseModel):
     simulator_version: BiosimulatorVersion
     status: BiosimSimulationRunStatus
     error_message: str | None = None
-    # cpus: Optional[int] = None
-    # memory: Optional[int] = None         # (in GB)
-    # maxTime: Optional[int] = None        # (in minutes)
-    # envVars: Optional[list[str]] = None  # list of environment variables (e.g., ["OMP_NUM_THREADS=4"])
-    # purpose: Optional[str] = None        # what does this correspond to?
-    # submitted: Optional[str] = None      # datetime string (e.g. 2025-01-10T19:51:11.424Z)
-    # updated: Optional[str] = None        # datetime string (e.g. 2025-01-10T19:51:11.424Z)
-    # projectSize: Optional[int] = None    # (in bytes)
-    # resultsSize: Optional[int] = None    # (in bytes)
-    # runtime: Optional[int] = None        # (in milliseconds)
-    # email: Optional[str] = None
+    # Run metadata returned by biosimulations.org. Optional because older cached
+    # documents predate these fields and some values are only populated once a run
+    # completes. Field names are snake_case here; the API uses camelCase (parsed in
+    # BiosimServiceRest). See tests/fixtures/local_data/biosim_run_response.json.
+    cpus: Optional[int] = None             # number of CPUs
+    memory: Optional[int] = None           # (in GB)
+    max_time: Optional[int] = None         # (in minutes)
+    env_vars: Optional[list[str]] = None   # environment variables (e.g., ["OMP_NUM_THREADS=4"])
+    purpose: Optional[str] = None          # e.g. "academic", "other"
+    submitted: Optional[str] = None        # datetime string (e.g. 2025-01-10T19:51:11.934Z)
+    updated: Optional[str] = None          # datetime string (e.g. 2025-01-10T19:51:41.807Z)
+    project_size: Optional[int] = None     # (in bytes)
+    results_size: Optional[int] = None     # (in bytes)
+    runtime: Optional[int] = None          # (in milliseconds)
+    email: Optional[str] = None
 
     @field_validator('id')
     def validate_id(cls, v: str) -> str:

--- a/backend/tests/biosim_runs/test_biosim_service.py
+++ b/backend/tests/biosim_runs/test_biosim_service.py
@@ -1,0 +1,63 @@
+"""Unit tests for parsing biosimulations.org /runs/{id} responses.
+
+No network: drives _sim_run_from_response against a captured payload
+(tests/fixtures/local_data/biosim_run_response.json) and a minimal one.
+"""
+
+import json
+from pathlib import Path
+from typing import Mapping
+
+from biosim_server.biosim_runs import BiosimulatorVersion
+from biosim_server.biosim_runs.biosim_service import _sim_run_from_response
+from biosim_server.biosim_runs.models import BiosimSimulationRunStatus
+
+
+def _simulator_version_from(res: Mapping[str, object]) -> BiosimulatorVersion:
+    return BiosimulatorVersion(
+        id=str(res["simulator"]),
+        name=str(res["simulator"]),
+        version=str(res["simulatorVersion"]),
+        image_url="",
+        image_digest=str(res["simulatorDigest"]),
+        created="",
+        updated="",
+    )
+
+
+def test_sim_run_from_response_parses_run_metadata(fixture_data_dir: Path) -> None:
+    """A full /runs/{id} payload populates the run-metadata fields."""
+    res = json.loads((fixture_data_dir / "biosim_run_response.json").read_text())
+    sim_run = _sim_run_from_response(res, _simulator_version_from(res))
+
+    assert sim_run.id == "67817a2e1f52f47f628af971"
+    assert sim_run.status == BiosimSimulationRunStatus.SUCCEEDED
+    assert sim_run.cpus == 1
+    assert sim_run.memory == 8
+    assert sim_run.max_time == 600
+    assert sim_run.env_vars == []
+    assert sim_run.purpose == "other"
+    assert sim_run.project_size == 283848
+    assert sim_run.results_size == 747060
+    assert sim_run.runtime == 29872
+    assert sim_run.submitted == "2025-01-10T19:51:11.934Z"
+    assert sim_run.updated == "2025-01-10T19:51:41.807Z"
+    assert sim_run.email is None
+
+
+def test_sim_run_from_minimal_response_leaves_metadata_none() -> None:
+    """A minimal payload (older/in-flight run) leaves the new fields None."""
+    res = {
+        "id": "abc123",
+        "name": "n",
+        "simulator": "copasi",
+        "simulatorVersion": "4.34.251",
+        "simulatorDigest": "sha256:x",
+        "status": "SUCCEEDED",
+    }
+    sim_run = _sim_run_from_response(res, _simulator_version_from(res))
+
+    assert sim_run.cpus is None
+    assert sim_run.env_vars is None
+    assert sim_run.runtime is None
+    assert sim_run.email is None

--- a/backend/tests/biosim_verify/test_omex_verify_workflows.py
+++ b/backend/tests/biosim_verify/test_omex_verify_workflows.py
@@ -72,6 +72,13 @@ def assert_omex_verify_results(observed_results: VerifyWorkflowOutput,
             expected_hdf5_file.id = result_hdf5_file.id
             expected_biosim_sim_run.id = result_biosim_sim_run.id
             expected_biosim_sim_run.simulator_version = result_biosim_sim_run.simulator_version
+            # run metadata (cpus/runtime/sizes/timestamps/...) is incidental to
+            # verification and varies between runs, so sync it like id/simulator_version
+            for _meta_field in ("cpus", "memory", "max_time", "env_vars", "purpose",
+                                "submitted", "updated", "project_size", "results_size",
+                                "runtime", "email"):
+                setattr(expected_biosim_sim_run, _meta_field,
+                        getattr(result_biosim_sim_run, _meta_field))
 
     # compare the comparison statistics separately, seems not to be 100% deterministic
     assert expected_results.workflow_results is not None

--- a/backend/tests/biosim_verify/test_runs_verify_workflow.py
+++ b/backend/tests/biosim_verify/test_runs_verify_workflow.py
@@ -112,6 +112,13 @@ def assert_runs_verify_results(observed_results: VerifyWorkflowOutput,
             expected_hdf5_file.id = result_hdf5_file.id
             expected_biosim_sim_run.id = result_biosim_sim_run.id
             expected_biosim_sim_run.simulator_version = result_biosim_sim_run.simulator_version
+            # run metadata (cpus/runtime/sizes/timestamps/...) is incidental to
+            # verification and varies between runs, so sync it like id/simulator_version
+            for _meta_field in ("cpus", "memory", "max_time", "env_vars", "purpose",
+                                "submitted", "updated", "project_size", "results_size",
+                                "runtime", "email"):
+                setattr(expected_biosim_sim_run, _meta_field,
+                        getattr(result_biosim_sim_run, _meta_field))
 
     # compare the comparison statistics separately, seems not to be 100% deterministic
     assert expected_results.workflow_results is not None

--- a/backend/tests/fixtures/local_data/biosim_run_response.json
+++ b/backend/tests/fixtures/local_data/biosim_run_response.json
@@ -1,0 +1,19 @@
+{
+    "id": "67817a2e1f52f47f628af971",
+    "name": "name",
+    "simulator": "vcell",
+    "simulatorVersion": "7.7.0.13",
+    "simulatorDigest": "sha256:828b2dc2b983de901c2d68eeb415cb22b46f1db04cdb9e8815d80bf451005216",
+    "cpus": 1,
+    "memory": 8,
+    "maxTime": 600,
+    "envVars": [],
+    "purpose": "other",
+    "status": "SUCCEEDED",
+    "submitted": "2025-01-10T19:51:11.934Z",
+    "updated": "2025-01-10T19:51:41.807Z",
+    "projectSize": 283848,
+    "resultsSize": 747060,
+    "runtime": 29872,
+    "email": null
+}


### PR DESCRIPTION
**PR1** of `docs/simulation-runs-convergence-plan.md`.

## Summary
biosimulations.org `/runs/{id}` returns `cpus, memory, maxTime, envVars, purpose, projectSize, resultsSize, runtime, submitted, updated, email` — but the client parsed only `id/name/simulator_version/status` and dropped the rest. (Confirmed by capturing a real response — see the new fixture.) This sources them so they're available to the rest of the system.

- **`BiosimSimulationRun`** gains those fields, all `Optional` with `None` defaults so older cached documents still validate.
- A shared **`_sim_run_from_response`** helper parses them via `res.get(...)` (robust to in-flight runs missing some), used by both `get_sim_run` and `run_biosim_sim`.
- The fields now persist inside the `BiosimulatorWorkflowRun` cache record — ready for **PR3** to join into the `/simulations/runs` listing (which still shows `0`/`[]` for these until then).

## Captured wire shape
`tests/fixtures/local_data/biosim_run_response.json` is a real `/runs/{id}` payload (run `67817a2e...`), confirming exact field names/types, e.g. `"cpus":1,"memory":8,"maxTime":600,"projectSize":283848,"runtime":29872,"email":null`.

## Testing
- `ruff` + `mypy --strict` clean.
- New `test_biosim_service.py`: parses the captured fixture (full payload) and a minimal payload (asserts missing fields → `None`, i.e. backward-compatible).
- The verify-workflow assert helpers now sync this **incidental, run-varying** metadata (`runtime`, `submitted`, sizes, …) from observed onto expected — exactly as they already do for `id`/`simulator_version` — since freshly-submitted OMEX runs produce different values each time and would otherwise break the golden-output equality. (Regenerating goldens would make the OMEX-verify test flaky.)
- Full `poetry run pytest -m "not integration"`: **78 passed, 1 failed** — the single failure is the pre-existing `test_slurm_service` (`UnboundLocalError`, needs SSH creds), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)