### PR TITLE
Converge SimulationRunWorkflow onto OmexSimWorkflow child (convergence PR2)

### DIFF
--- a/backend/biosim_server/simulations/__init__.py
+++ b/backend/biosim_server/simulations/__init__.py
@@ -1,6 +1,4 @@
 from biosim_server.simulations.activities import (
-    submit_simulation_activity,
-    poll_simulation_activity,
     update_run_status_activity,
 )
 from biosim_server.simulations.database import (
@@ -24,8 +22,6 @@ from biosim_server.simulations.router import router as simulations_router
 from biosim_server.simulations.workflow import SimulationRunWorkflow, SimulationRunWorkflowInput
 
 __all__ = [
-    "submit_simulation_activity",
-    "poll_simulation_activity",
     "update_run_status_activity",
     "SimulationRunDatabaseService",
     "SimulationRunDatabaseServiceMongo",

--- a/backend/biosim_server/simulations/activities.py
+++ b/backend/biosim_server/simulations/activities.py
@@ -1,153 +1,16 @@
-"""Activities for the simulation run workflow.
+"""Activity for recording user-facing simulation run status.
 
-Split into submit and poll phases so the parent workflow can capture
-the biosimulations_run_id immediately after submission.
+The biosimulations.org submit/poll/save now runs in OmexSimWorkflow (shared with
+the verification path); this module only records the per-submission status that
+backs the /simulations/runs listing.
 """
 
-import asyncio
 import logging
-import os
 
-from aiohttp import ClientResponseError
 from pydantic import BaseModel
 from temporalio import activity
 
-from biosim_server.biosim_omex import OmexFile
-from biosim_server.biosim_runs.models import (
-    BiosimSimulationRun,
-    BiosimSimulationRunStatus,
-    BiosimulatorVersion,
-    BiosimulatorWorkflowRun,
-    HDF5File,
-)
-from biosim_server.common.storage import FileService
-from biosim_server.dependencies import (
-    get_biosim_service,
-    get_database_service,
-    get_file_service,
-    get_simulation_run_database_service,
-)
-
-
-class SubmitSimulationInput(BaseModel):
-    omex_file: OmexFile
-    simulator_version: BiosimulatorVersion
-    cache_buster: str
-
-
-class SubmitSimulationOutput(BaseModel):
-    biosimulations_run_id: str | None = None
-    cached: bool = False
-    source: str  # "submitted" or "cached"
-
-
-@activity.defn
-async def submit_simulation_activity(input: SubmitSimulationInput) -> SubmitSimulationOutput:
-    """Submit simulation to biosimulations.org and return the run ID immediately."""
-    activity.logger.setLevel(logging.INFO)
-
-    # Check cache first
-    database_service = get_database_service()
-    assert database_service is not None
-    cached_runs = await database_service.get_biosimulator_workflow_runs(
-        file_hash_md5=input.omex_file.file_hash_md5,
-        image_digest=input.simulator_version.image_digest,
-        cache_buster=input.cache_buster,
-    )
-    if (len(cached_runs) > 0 and cached_runs[0].biosim_run is not None
-            and cached_runs[0].biosim_run.status == BiosimSimulationRunStatus.SUCCEEDED):
-        activity.logger.info(f"Cache hit for {input.simulator_version.id}:{input.simulator_version.version}")
-        return SubmitSimulationOutput(
-            biosimulations_run_id=cached_runs[0].biosim_run.id,
-            cached=True,
-            source="cached",
-        )
-
-    # Submit to biosimulations.org
-    biosim_service = get_biosim_service()
-    if biosim_service is None:
-        raise Exception("Biosim service is not initialized")
-    file_service: FileService | None = get_file_service()
-    if file_service is None:
-        raise Exception("File service is not initialized")
-
-    (_gcs_path, local_omex_path) = await file_service.download_file(gcs_path=input.omex_file.omex_gcs_path)
-    activity.logger.info(f"Downloaded OMEX file to {local_omex_path}")
-
-    simulation_run = await biosim_service.run_biosim_sim(
-        local_omex_path=local_omex_path,
-        omex_name=input.omex_file.uploaded_filename,
-        simulator_version=input.simulator_version,
-    )
-    os.remove(local_omex_path)
-
-    activity.logger.info(f"Submitted {input.simulator_version.id}:{input.simulator_version.version}, "
-                         f"biosimulations_run_id={simulation_run.id}")
-    return SubmitSimulationOutput(
-        biosimulations_run_id=simulation_run.id,
-        cached=False,
-        source="submitted",
-    )
-
-
-class PollSimulationInput(BaseModel):
-    workflow_id: str
-    omex_file: OmexFile
-    simulator_version: BiosimulatorVersion
-    cache_buster: str
-    biosimulations_run_id: str
-
-
-@activity.defn
-async def poll_simulation_activity(input: PollSimulationInput) -> BiosimulatorWorkflowRun:
-    """Poll biosimulations.org for completion, fetch HDF5, save to DB."""
-    activity.logger.setLevel(logging.INFO)
-
-    biosim_service = get_biosim_service()
-    if biosim_service is None:
-        raise Exception("Biosim service is not initialized")
-    database_service = get_database_service()
-    assert database_service is not None
-
-    # Poll until complete
-    simulation_run: BiosimSimulationRun = await biosim_service.get_sim_run(input.biosimulations_run_id)
-    while simulation_run.status not in [BiosimSimulationRunStatus.SUCCEEDED, BiosimSimulationRunStatus.FAILED,
-                                        BiosimSimulationRunStatus.RUN_ID_NOT_FOUND]:
-        await asyncio.sleep(3)
-        activity.heartbeat("Polling simulation run status")
-        simulation_run = await biosim_service.get_sim_run(input.biosimulations_run_id)
-
-    # Fetch HDF5 metadata with retries (simdata API can lag)
-    hdf5_file: HDF5File | None = None
-    if simulation_run.status == BiosimSimulationRunStatus.SUCCEEDED:
-        max_retries = 10
-        for attempt in range(max_retries):
-            try:
-                hdf5_file = await biosim_service.get_hdf5_metadata(simulation_run.id)
-                break
-            except ClientResponseError as e:
-                if e.status == 404 and attempt < max_retries - 1:
-                    activity.logger.info(f"HDF5 metadata not yet available for run {simulation_run.id}, "
-                                         f"retrying in 10s (attempt {attempt + 1}/{max_retries})")
-                    activity.heartbeat("Waiting for HDF5 metadata")
-                    await asyncio.sleep(10)
-                else:
-                    raise e
-
-    # Save to DB
-    biosim_workflow_run = BiosimulatorWorkflowRun(
-        workflow_id=input.workflow_id,
-        file_hash_md5=input.omex_file.file_hash_md5,
-        image_digest=input.simulator_version.image_digest,
-        cache_buster=input.cache_buster,
-        omex_file=input.omex_file,
-        simulator_version=input.simulator_version,
-        biosim_run=simulation_run,
-        hdf5_file=hdf5_file,
-    )
-    saved = await database_service.insert_biosimulator_workflow_run(sim_workflow_run=biosim_workflow_run)
-    activity.logger.info(f"Saved BiosimulatorWorkflowRun _id={saved.database_id}")
-    return saved
+from biosim_server.dependencies import get_simulation_run_database_service
 
 
 class UpdateRunStatusInput(BaseModel):

--- a/backend/biosim_server/simulations/workflow.py
+++ b/backend/biosim_server/simulations/workflow.py
@@ -1,22 +1,22 @@
 import asyncio
 import logging
 from datetime import timedelta
+from typing import Any, Coroutine
 
 from pydantic import BaseModel
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.workflow import ChildWorkflowHandle
 
 from biosim_server.biosim_omex import OmexFile
-from biosim_server.biosim_runs import BiosimulatorVersion, BiosimSimulationRunStatus
-from biosim_server.simulations.activities import (
-    SubmitSimulationInput,
-    SubmitSimulationOutput,
-    submit_simulation_activity,
-    PollSimulationInput,
-    poll_simulation_activity,
-    UpdateRunStatusInput,
-    update_run_status_activity,
+from biosim_server.biosim_runs import (
+    BiosimulatorVersion,
+    OmexSimWorkflow,
+    OmexSimWorkflowInput,
+    OmexSimWorkflowOutput,
+    OmexSimWorkflowStatus,
 )
+from biosim_server.simulations.activities import UpdateRunStatusInput, update_run_status_activity
 from biosim_server.simulations.models import SimulationJobStatus, ConglomerateStatus, job_status_to_display
 
 
@@ -56,90 +56,51 @@ class SimulationRunWorkflow:
         workflow.logger.setLevel(level=logging.INFO)
         workflow.logger.info("SimulationRunWorkflow started.")
 
-        # Phase 1: Submit all simulations in parallel, capture run IDs immediately
-        submit_tasks = []
+        # Run each simulator via a child OmexSimWorkflow — the same per-run unit the
+        # verification path uses. Each child submits to biosimulations.org, polls to
+        # completion, and persists a BiosimulatorWorkflowRun (shared result cache).
+        child_workflows: list[
+            Coroutine[Any, Any, ChildWorkflowHandle[OmexSimWorkflowInput, OmexSimWorkflowOutput]]] = []
         for sim in workflow_input.simulators:
-            submit_tasks.append(
-                workflow.execute_activity(
-                    submit_simulation_activity,
-                    args=[SubmitSimulationInput(
+            child_workflows.append(
+                workflow.start_child_workflow(
+                    OmexSimWorkflow.run,  # type: ignore
+                    args=[OmexSimWorkflowInput(
                         omex_file=workflow_input.omex_file,
                         simulator_version=sim,
                         cache_buster=workflow_input.cache_buster,
                     )],
-                    start_to_close_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    result_type=OmexSimWorkflowOutput,
+                    task_queue="verification_tasks",
+                    execution_timeout=timedelta(minutes=30),
                 )
             )
 
-        submit_results: list[SubmitSimulationOutput | BaseException] = await asyncio.gather(
-            *submit_tasks, return_exceptions=True)
+        child_handles: list[ChildWorkflowHandle[OmexSimWorkflowInput, OmexSimWorkflowOutput]] = \
+            await asyncio.gather(*child_workflows)
 
-        # Update job statuses with run IDs from submit phase
-        for job_id, sim, result in zip(workflow_input.job_ids, workflow_input.simulators, submit_results):
-            if isinstance(result, BaseException):
-                self.job_statuses[job_id].status = "failure"
-                self.job_statuses[job_id].error = str(result)
-            elif result.biosimulations_run_id is not None:
-                self.job_statuses[job_id].biosimulations_run_id = result.biosimulations_run_id
+        # Await each child and map its outcome onto the per-job status. A child that
+        # raises (e.g. submit failed) must not abort the others, hence return_exceptions.
+        child_outputs = await asyncio.gather(*child_handles, return_exceptions=True)
 
-        workflow.logger.info("Submit phase complete, starting poll phase.")
-
-        # Phase 2: Poll for completion in parallel (only for successfully submitted jobs)
-        poll_tasks = []
-        poll_job_ids = []
-        for job_id, sim, result in zip(workflow_input.job_ids, workflow_input.simulators, submit_results):
-            if isinstance(result, BaseException):
+        for job_id, output in zip(workflow_input.job_ids, child_outputs):
+            job = self.job_statuses[job_id]
+            if isinstance(output, BaseException):
+                job.status = "failure"
+                job.error = str(output)
                 continue
-            if result.biosimulations_run_id is None:
-                self.job_statuses[job_id].status = "failure"
-                self.job_statuses[job_id].error = "No biosimulations run ID returned"
-                continue
+            run_record = output.biosimulator_workflow_run
+            if run_record is not None and run_record.biosim_run is not None:
+                job.biosimulations_run_id = run_record.biosim_run.id
+            if output.workflow_status == OmexSimWorkflowStatus.COMPLETED:
+                job.status = "success"
+            else:
+                job.status = "failure"
+                job.error = output.error_message or "Simulation did not complete successfully"
 
-            if result.cached:
-                # Already completed successfully from cache
-                self.job_statuses[job_id].status = "success"
-                continue
-
-            poll_job_ids.append(job_id)
-            poll_tasks.append(
-                workflow.execute_activity(
-                    poll_simulation_activity,
-                    args=[PollSimulationInput(
-                        workflow_id=workflow.info().workflow_id,
-                        omex_file=workflow_input.omex_file,
-                        simulator_version=sim,
-                        cache_buster=workflow_input.cache_buster,
-                        biosimulations_run_id=result.biosimulations_run_id,
-                    )],
-                    start_to_close_timeout=timedelta(minutes=20),
-                    heartbeat_timeout=timedelta(minutes=2),
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
-            )
-
-        if poll_tasks:
-            poll_results = await asyncio.gather(*poll_tasks, return_exceptions=True)
-            for job_id, poll_result in zip(poll_job_ids, poll_results):
-                if isinstance(poll_result, BaseException):
-                    self.job_statuses[job_id].status = "failure"
-                    self.job_statuses[job_id].error = str(poll_result)
-                elif (poll_result.biosim_run is not None
-                      and poll_result.biosim_run.status == BiosimSimulationRunStatus.SUCCEEDED):
-                    self.job_statuses[job_id].status = "success"
-                else:
-                    self.job_statuses[job_id].status = "failure"
-                    if poll_result.biosim_run is not None:
-                        status = poll_result.biosim_run.status
-                        msg = poll_result.biosim_run.error_message
-                        self.job_statuses[job_id].error = msg or f"Simulation ended with status: {status}"
-                    else:
-                        self.job_statuses[job_id].error = "Unknown error: no simulation run returned"
-
-        # Persist each job's terminal status to the queryable runs collection.
-        # Records were created (status CREATED) by the API at submission time;
-        # this maps run_id -> SimulationRunRecord.run_id. Failures here must not
-        # fail the run, so exceptions are swallowed.
+        # Persist each job's terminal status to the queryable runs collection. Records
+        # were created (status CREATED) by the API at submission time; this maps
+        # run_id -> SimulationRunRecord.run_id. Failures here must not fail the run.
         update_tasks = []
         for job_id, job in self.job_statuses.items():
             update_tasks.append(

--- a/backend/biosim_server/worker/worker_main.py
+++ b/backend/biosim_server/worker/worker_main.py
@@ -9,8 +9,7 @@ from biosim_server.biosim_runs import get_existing_biosim_simulation_run_activit
 from biosim_server.biosim_verify.activities import generate_statistics_activity
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflow
-from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity, \
-    update_run_status_activity
+from biosim_server.simulations.activities import update_run_status_activity
 from biosim_server.simulations.workflow import SimulationRunWorkflow
 from biosim_server.dependencies import get_temporal_client, init_standalone
 
@@ -34,8 +33,7 @@ async def main() -> None:
         task_queue="verification_tasks",
         workflows=[OmexVerifyWorkflow, OmexSimWorkflow, RunsVerifyWorkflow, SimulationRunWorkflow],
         activities=[get_existing_biosim_simulation_run_activity, submit_biosim_simulation_run_activity,
-                    generate_statistics_activity, submit_simulation_activity, poll_simulation_activity,
-                    update_run_status_activity],
+                    generate_statistics_activity, update_run_status_activity],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     run_futures.append(handle.run())

--- a/backend/tests/fixtures/temporal_fixtures.py
+++ b/backend/tests/fixtures/temporal_fixtures.py
@@ -11,8 +11,7 @@ from biosim_server.biosim_runs import get_existing_biosim_simulation_run_activit
 from biosim_server.biosim_verify.activities import generate_statistics_activity
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflow
-from biosim_server.simulations.activities import submit_simulation_activity, poll_simulation_activity, \
-    update_run_status_activity
+from biosim_server.simulations.activities import update_run_status_activity
 from biosim_server.simulations.workflow import SimulationRunWorkflow
 from biosim_server.common.temporal import pydantic_data_converter
 from biosim_server.dependencies import get_temporal_client, set_temporal_client
@@ -50,8 +49,7 @@ async def temporal_verify_worker(temporal_client: Client) -> AsyncGenerator[Work
             task_queue="verification_tasks",
             workflows=[OmexVerifyWorkflow, OmexSimWorkflow, RunsVerifyWorkflow, SimulationRunWorkflow],
             activities=[generate_statistics_activity, get_existing_biosim_simulation_run_activity,
-                        submit_biosim_simulation_run_activity, submit_simulation_activity,
-                        poll_simulation_activity, update_run_status_activity],
+                        submit_biosim_simulation_run_activity, update_run_status_activity],
             debug_mode=True,
             workflow_runner=UnsandboxedWorkflowRunner()
     ) as worker:

--- a/docs/simulation-runs-convergence-plan.md
+++ b/docs/simulation-runs-convergence-plan.md
@@ -134,6 +134,19 @@ child workflow; delete `simulations/activities.py`'s duplicate
 5. Drop the deleted activities from `worker_main.py` and `temporal_fixtures.py`;
    register the new biosim_runs submit/poll pair.
 
+**Implemented (2026-05-29) — simpler than steps 1–2 above.** Splitting the activity
+to surface `run_id` *early* turned out unnecessary and was skipped: a Temporal parent
+cannot **query** a running child (queries are client-side, not workflow-to-workflow),
+so "early run_id" would require a child→parent signal. Instead `SimulationRunWorkflow`
+composes `OmexSimWorkflow` children with the existing **monolithic activity unchanged**,
+and reads each child's `run_id`/status from its **output at completion**. This keeps the
+verification production path 100% untouched (lowest risk) and still retires the duplicate
+`submit_simulation_activity` / `poll_simulation_activity` — leaving the monolithic
+`submit_biosim_simulation_run_activity` as the single shared per-run implementation. The
+only behavior change: `biosimulations_run_id` appears in the live `/simulations/{id}`
+status query once a run **completes** rather than right after submit (untested, minor;
+recoverable later via a child→parent signal if a use case needs it).
+
 **API contract:** unchanged.
 
 **Ship/test gate:**
@@ -215,3 +228,38 @@ fields → the row renders as "still running." A unique index on the computation
 side makes the join target well-defined; any hard "referenced run must exist"
 guarantee is an application check (optionally inside a transaction), never a
 schema constraint.
+
+---
+
+## TODO: assess `biosim-client` impact (external API consumer)
+
+`biosim-client` (`../biosim-client`, https://github.com/biosimulations/biosim-client)
+is a Python client library for **this platform's** API — the original
+`biosim.biosimulations.org`, now served at `api.biosim.biosimulations.org`. It is an
+**external consumer** of the endpoints and response models this convergence work
+touches, so changes here can break it:
+
+- **PR1 (merged)** added fields to `BiosimSimulationRun`, which is embedded in the
+  `/verify/*` responses — additive, so likely backward-compatible, but unverified
+  against the client's deserialization.
+- **PR3 (planned)** normalizes `SimulationRunRecord` and may reshape `/simulations/runs`
+  response assembly — higher risk of a breaking change.
+- **PR2 (this)** kept the API contract unchanged — no client impact expected.
+
+**Plan:**
+1. **Inventory** which endpoints/models `biosim-client` consumes (clone/read
+   `../biosim-client`; grep its generated models / request code against our
+   `api/main.py` + `simulations`/`biosim_verify` response models).
+2. **Diff** that surface against the changes in PR1 (landed) and PR3 (planned);
+   flag any removed/renamed/retyped fields. Additive optional fields are usually
+   safe; field removals/renames and required-field changes are not.
+3. **Versioning/contract:** decide whether to pin a client version, add a contract
+   test (e.g. validate the client's models against our OpenAPI schema in CI), or
+   coordinate a client release alongside breaking API changes.
+4. **Consider monorepo absorption:** evaluate bringing `biosim-client` into this
+   repo (e.g. `clients/python/`) so API + client version and test together, with
+   the client's models generated from our OpenAPI schema. Weigh against its
+   independent release cadence and external (non-platform) consumers.
+
+Owner/when: TBD — do the inventory (step 1) before PR3 lands, since PR3 is the most
+likely to break the client.

--- a/docs/workflows-architecture.md
+++ b/docs/workflows-architecture.md
@@ -1,0 +1,416 @@
+# Simulation Workflows & Activities — Architecture
+
+A high-level design reference for the Temporal workflows and activities that
+back the **verification** (`/verify/*`) and **simulation-run** (`/simulations/*`)
+subsystems, including how they relate, what has changed during the run-listing
+convergence work, and what's proposed next.
+
+Companion docs:
+- [`simulation-runs-api-plan.md`](simulation-runs-api-plan.md) — the original `/simulations/runs` plan.
+- [`simulation-runs-convergence-plan.md`](simulation-runs-convergence-plan.md) — sequenced PR plan (PR0–PR3) and external-consumer TODO.
+
+---
+
+## Domain primitives
+
+**Temporal model.** Workflows are deterministic, replayable orchestrators that
+must do **no I/O** (no DB, no network, no clocks, no random). Activities are the
+**side-effect boundary** — they own all I/O (HTTP, MongoDB, GCS, files, time).
+Any database write in this system happens inside an activity.
+
+**The per-run unit.** "Submit one OMEX archive to biosimulations.org for one
+simulator, poll until terminal, fetch HDF5 metadata, and persist the result" is
+the reusable unit. It is implemented today by **`OmexSimWorkflow`** (a child
+workflow) backed by **`submit_biosim_simulation_run_activity`** (a monolithic
+activity that bundles submit + poll + HDF5 + save). PR2 makes this unit shared
+by both `OmexVerifyWorkflow` and `SimulationRunWorkflow`.
+
+**Two storage entities for "a simulation":**
+- `BiosimulatorWorkflowRun` (collection `BiosimSims`) — the **computation/artifact** record.
+  Keyed by `(file_hash_md5, image_digest, cache_buster)`. Many submissions can
+  map to one of these (cache deduplication).
+- `SimulationRunRecord` (collection `BiosimSimulationRuns`) — the **submission ledger**.
+  One per `(user submission × simulator)`. Carries user-facing identity (`name`,
+  `email`, `purpose`, timestamps, display status) and a reference to the
+  computation via `biosimulations_run_id`.
+
+---
+
+## Verification workflows (current state, unchanged by the convergence)
+
+Two entry points, both producing pairwise NxN comparison statistics:
+
+| Endpoint | Workflow | Per-run mechanism |
+|---|---|---|
+| `POST /verify/omex` | `OmexVerifyWorkflow` | starts N `OmexSimWorkflow` children (one per simulator) |
+| `POST /verify/runs` | `RunsVerifyWorkflow` | imports N pre-existing biosimulations runs via `get_existing_biosim_simulation_run_activity` |
+
+```mermaid
+flowchart LR
+    subgraph "API"
+        EP1["POST /verify/omex"]
+        EP2["POST /verify/runs"]
+    end
+    subgraph "Temporal: parent workflows"
+        OVW["OmexVerifyWorkflow"]
+        RVW["RunsVerifyWorkflow"]
+    end
+    subgraph "Temporal: child per-run unit"
+        OSW["OmexSimWorkflow x N"]
+    end
+    subgraph "Temporal: activities"
+        SBA["submit_biosim_simulation_run_activity<br/>(monolithic: cache-check → submit → poll → HDF5 → save)"]
+        GERA["get_existing_biosim_simulation_run_activity<br/>(import existing run)"]
+        GSA["generate_statistics_activity<br/>(NxN pairwise comparison)"]
+    end
+    subgraph "Storage / External"
+        DB_OMEX[("BiosimOmex")]
+        DB_SIMS[("BiosimSims")]
+        EXT(["biosimulations.org<br/>simdata API"])
+    end
+    EP1 --> OVW
+    EP2 --> RVW
+    OVW -- "start_child_workflow x N" --> OSW
+    OSW -- "execute_activity" --> SBA
+    RVW -- "execute_activity x N" --> GERA
+    OVW -- "execute_activity" --> GSA
+    RVW -- "execute_activity" --> GSA
+    SBA -- "HTTP submit/poll/HDF5" --> EXT
+    SBA -- "read cache, write result" --> DB_SIMS
+    SBA -- "read OMEX path" --> DB_OMEX
+    GERA -- "HTTP get run" --> EXT
+    GERA -- "read/write" --> DB_SIMS
+```
+
+Key properties:
+- `OmexSimWorkflow` (`biosim_runs/workflows.py`) is the **only place** that
+  starts a fresh biosimulations.org run. It exposes a `@workflow.query` for its
+  output but, today, the run_id is not populated on the queryable state until
+  the monolithic activity returns at the end.
+- `generate_statistics_activity` is shared by both verify workflows.
+- `BiosimSims` is a **shared cache** — a workflow that finds a `SUCCEEDED`
+  record for the same `(file_hash, image_digest, cache_buster)` reuses it
+  instead of re-submitting.
+
+---
+
+## Simulation-run workflow — evolution
+
+A user-facing path: the webapp submits an OMEX archive against one or more
+simulators and later browses the runs in a table. This subsystem has gone
+through three shapes; the convergence work is bringing it onto the verification
+path's primitives.
+
+### Shape A — original (pre-convergence)
+
+`SimulationRunWorkflow` had its **own** submit/poll/save activity pair
+(`submit_simulation_activity`, `poll_simulation_activity` in
+`simulations/activities.py`) that duplicated the verify path's monolithic logic.
+
+```mermaid
+flowchart LR
+    subgraph "API"
+        EP["POST /simulations/run"]
+        EPL["POST /simulations/runs<br/>(listing)"]
+        EPS["GET /simulations/{id}<br/>(status)"]
+    end
+    subgraph "Temporal"
+        SRW["SimulationRunWorkflow"]
+        SS["submit_simulation_activity x N<br/>(DUPLICATE submit half)"]
+        PS["poll_simulation_activity x N<br/>(DUPLICATE poll + save half)"]
+        URS["update_run_status_activity"]
+    end
+    subgraph "Storage"
+        DBR[("BiosimSimulationRuns<br/>(submission ledger)")]
+        DB_SIMS[("BiosimSims<br/>(shared cache)")]
+        EXT(["biosimulations.org"])
+    end
+    EP -- "start workflow" --> SRW
+    EP -- "insert N records (status=CREATED)" --> DBR
+    SRW -- "phase 1: x N parallel" --> SS
+    SRW -- "phase 2: x N parallel" --> PS
+    SS -- "HTTP submit" --> EXT
+    SS -- "read cache" --> DB_SIMS
+    PS -- "HTTP poll/HDF5" --> EXT
+    PS -- "write result" --> DB_SIMS
+    SRW -- "after both phases x N" --> URS
+    URS -- "set SUCCEEDED/FAILED + biosim_run_id" --> DBR
+    EPS -- "query workflow" --> SRW
+    EPL -- "read & filter" --> DBR
+```
+
+The duplication was the core liability: two implementations of the same logic
+(cache lookup, HTTP submit, polling loop, HDF5-404 retry, BiosimulatorWorkflowRun
+insertion) drifting against each other.
+
+### Shape B — PR2 / [#51](https://github.com/biosimulations/platform/pull/51) (open)
+
+`SimulationRunWorkflow` now runs each simulator via a child **`OmexSimWorkflow`** —
+the same per-run unit the verify path uses. The duplicate
+`submit_simulation_activity` / `poll_simulation_activity` are **deleted**. The
+monolithic `submit_biosim_simulation_run_activity` becomes the single shared
+implementation.
+
+```mermaid
+flowchart LR
+    subgraph "API"
+        EP["POST /simulations/run"]
+        EPL["POST /simulations/runs"]
+        EPS["GET /simulations/{id}"]
+    end
+    subgraph "Temporal: parent"
+        SRW["SimulationRunWorkflow"]
+    end
+    subgraph "Temporal: child per-run unit (SHARED with verify)"
+        OSW["OmexSimWorkflow x N"]
+    end
+    subgraph "Temporal: activities"
+        SBA["submit_biosim_simulation_run_activity<br/>(monolithic, SHARED)"]
+        URS["update_run_status_activity"]
+    end
+    subgraph "Storage"
+        DBR[("BiosimSimulationRuns")]
+        DB_SIMS[("BiosimSims")]
+        EXT(["biosimulations.org"])
+    end
+    EP --> SRW
+    EP -- "insert N records (CREATED)" --> DBR
+    SRW -- "start_child_workflow x N" --> OSW
+    OSW -- "execute_activity" --> SBA
+    SBA -- "HTTP" --> EXT
+    SBA -- "read/write" --> DB_SIMS
+    SRW -- "after children complete" --> URS
+    URS -- "set SUCCEEDED/FAILED + biosim_run_id" --> DBR
+    EPS -- "query workflow" --> SRW
+    EPL -- "read & filter" --> DBR
+```
+
+What changed and what didn't:
+- ✅ One orchestration unit (`OmexSimWorkflow`) for both paths.
+- ✅ Duplicate submit/poll activities deleted.
+- ✅ **Verification production path entirely untouched** — PR2's diff is only
+  `simulations/*`, `worker_main.py`, `temporal_fixtures.py`.
+- ⚠️ `biosimulations_run_id` only surfaces in the live `GET /simulations/{id}`
+  status when each child completes (the monolithic activity bundles submit +
+  poll, so the workflow learns the run_id only at the end). The listing isn't
+  affected — it gets the id at completion either way.
+
+### Shape C — proposed PR2.5 (activity split + early DB write)
+
+The observation that motivates PR2.5: **activities are the canonical place to
+write to a database in Temporal.** Once you split the monolithic activity, the
+workflow has a moment between "I know the run_id" and "I'm done polling" — and
+in that moment it can fire a small DB-write activity to record the run_id
+**early**, persistently, in `SimulationRunRecord`. No child→parent signal
+needed; just an activity doing what activities are for.
+
+```mermaid
+flowchart LR
+    subgraph "API"
+        EP["POST /simulations/run"]
+        EPS["GET /simulations/{id}<br/>(hybrid read)"]
+    end
+    subgraph "Temporal: parent"
+        SRW["SimulationRunWorkflow"]
+    end
+    subgraph "Temporal: child per-run unit (SHARED)"
+        OSW["OmexSimWorkflow x N<br/>(now takes optional submission_run_id)"]
+    end
+    subgraph "Temporal: activities"
+        SUB["submit_biosim_run_activity<br/>(NEW — submit half of split)"]
+        URS["update_run_status_activity<br/>(EARLY when submission_run_id is set)"]
+        POLL["poll_biosim_run_activity<br/>(NEW — poll + HDF5 + save half)"]
+    end
+    subgraph "Storage"
+        DBR[("BiosimSimulationRuns")]
+        DB_SIMS[("BiosimSims")]
+        EXT(["biosimulations.org"])
+    end
+    EP --> SRW
+    EP -- "insert N records (CREATED)" --> DBR
+    SRW -- "start child x N (pass job_id as submission_run_id)" --> OSW
+    OSW -- "1. execute" --> SUB
+    SUB -- "HTTP submit" --> EXT
+    SUB -- "read cache" --> DB_SIMS
+    OSW -- "2. execute (if submission_run_id)" --> URS
+    URS -- "write biosim_run_id (EARLY)" --> DBR
+    OSW -- "3. execute" --> POLL
+    POLL -- "HTTP poll + HDF5" --> EXT
+    POLL -- "write result" --> DB_SIMS
+    SRW -- "after children complete" --> URS
+    EPS -- "query workflow (status)<br/>+ read DBR (biosim_run_id)" --> SRW
+    EPS -- "(DB read)" --> DBR
+```
+
+Key properties:
+- `OmexSimWorkflowInput` gains an optional `submission_run_id` (= the per-job
+  UUID = `SimulationRunRecord.run_id`). The verify path passes `None` →
+  step 2 above is skipped → **zero behavior change to verification**.
+- The status endpoint becomes a hybrid read: workflow query for live status,
+  DB record for run_id (and any other submission metadata).
+- The monolithic activity is replaced by the split pair; `OmexSimWorkflow`,
+  `OmexVerifyWorkflow`, and `SimulationRunWorkflow` all benefit from the cleaner
+  decomposition.
+
+### Sequence — the run lifecycle after PR2.5
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Webapp
+    participant API as FastAPI router
+    participant DBR as BiosimSimulationRuns
+    participant SRW as SimulationRunWorkflow
+    participant OSW as OmexSimWorkflow<br/>(child, one per simulator)
+    participant SUB as submit_biosim_run_activity
+    participant URS as update_run_status_activity
+    participant POLL as poll_biosim_run_activity
+    participant DBS as BiosimSims
+    participant EXT as biosimulations.org
+
+    U->>API: POST /simulations/run (omex_id, name, simulators[], email, cache_buster?)
+    API->>DBR: insert N records (status=CREATED, run_id=job_id)
+    API->>SRW: start workflow (job_ids[], cache_buster)
+    API-->>U: 202 { processing_id, jobs: [{run_id, status=processing}, ...] }
+
+    par per simulator
+        SRW->>OSW: start child (submission_run_id=job_id)
+        OSW->>SUB: execute submit (cache_buster, simulator)
+        SUB->>DBS: read cache
+        alt cache hit (SUCCEEDED)
+            SUB-->>OSW: cached biosimulations_run_id
+        else cache miss
+            SUB->>EXT: POST /runs (submit)
+            EXT-->>SUB: new biosimulations_run_id
+        end
+        OSW->>URS: write biosim_run_id (EARLY, while still running)
+        URS->>DBR: set run_id (status still CREATED)
+        OSW->>POLL: execute poll (run_id)
+        POLL->>EXT: GET /runs/{id} (poll until terminal)
+        POLL->>EXT: GET HDF5 metadata
+        POLL->>DBS: insert BiosimulatorWorkflowRun
+        POLL-->>OSW: full record
+        OSW-->>SRW: OmexSimWorkflowOutput (status, run record)
+    end
+
+    SRW->>URS: write terminal status (SUCCEEDED or FAILED)
+    URS->>DBR: update status (+ runtime, etc.)
+
+    loop polling
+        U->>API: GET /simulations/{processing_id}
+        API->>SRW: query get_status
+        API->>DBR: read run_ids by processing_id
+        API-->>U: ConglomerateStatus (status from workflow, run_ids from DB)
+    end
+
+    U->>API: POST /simulations/runs (listing query)
+    API->>DBR: filter/sort/paginate
+    API-->>U: { runs[], pagination }
+```
+
+Steps 4–6 (the early DB write) and step 12 (hybrid status read) are the PR2.5
+delta. Everything above the dashed band is in #51 today.
+
+---
+
+## Storage layer
+
+```mermaid
+erDiagram
+    BiosimOmex {
+        string file_hash_md5 PK
+        string omex_gcs_path
+        string uploaded_filename
+        int    file_size
+    }
+    BiosimSims {
+        string file_hash_md5
+        string image_digest
+        string cache_buster
+        object omex_file
+        object simulator_version
+        object biosim_run "embeds BiosimSimulationRun (id, status, cpus, memory, runtime, ...)"
+        object hdf5_file
+    }
+    BiosimSimulationRuns {
+        string run_id PK "= per-(submission × simulator) job UUID"
+        string processing_id "= parent workflow id"
+        string biosimulations_run_id FK "ref BiosimSims.biosim_run.id (manual)"
+        string name "user-supplied label"
+        string simulator
+        string simulator_version
+        string email
+        string purpose
+        string status "CREATED | SUCCEEDED | FAILED"
+        string cache_buster
+        date   submitted
+        date   updated
+    }
+    BiosimCompare {
+        string workflow_id PK
+        object comparison_statistics
+    }
+    BiosimSims ||--o| BiosimOmex : "file_hash_md5"
+    BiosimSimulationRuns }o--|| BiosimSims : "biosimulations_run_id → biosim_run.id (many-to-one; cache dedup)"
+```
+
+Two intentional choices to call out:
+
+1. **`BiosimSims` is a deduplicated *computation/artifact* table.** With caching
+   on, many submissions of the same `(omex, simulator, cache_buster)` map to
+   one `BiosimulatorWorkflowRun`. That's the result-provenance + cache role.
+2. **`BiosimSimulationRuns` is the *submission ledger.*** One per user action,
+   even on a cache hit. It carries identity (`email`, user-chosen `name`,
+   `purpose`), submission timestamps, and a *display* status
+   (`CREATED/SUCCEEDED/FAILED`) — three categories the listing UI actually uses.
+
+In MongoDB the relationship is a **manual reference**, not a foreign-key
+constraint (Mongo has no FKs). Orphans (a submission with no completed
+computation yet) are normal mid-flight states — an app-side left join yields
+`null` computed fields and the row renders as "still running."
+
+---
+
+## PR3 preview — normalize the submission ledger
+
+PR3 will slim `SimulationRunRecord` to submission-owned fields plus the
+`biosimulations_run_id` FK, and have the listing **app-side join** to
+`BiosimulatorWorkflowRun` for computed/derived fields (digest, cpus, sizes,
+runtime, …). The current denormalization (copying those columns onto every
+submission row and writing them back via `update_run_status_activity`) is the
+real "two-table awkwardness" — the *existence* of two tables is correct; the
+*duplicated columns* are the smell.
+
+```mermaid
+flowchart LR
+    subgraph "after PR3"
+        SUB["SimulationRunRecord<br/>(slim: run_id, processing_id, name, email,<br/>purpose, status, submitted, updated,<br/>cache_buster, biosimulations_run_id)"]
+        COMP["BiosimulatorWorkflowRun<br/>(computation + artifacts +<br/>biosim_run metadata: cpus, memory,<br/>runtime, projectSize, ...)"]
+        LIST["POST /simulations/runs"]
+    end
+    LIST -- "1. filter/sort/paginate submissions" --> SUB
+    LIST -- "2. batch fetch by biosimulations_run_id $in [...]" --> COMP
+    LIST -- "3. stitch into SimulationRun DTO" --> LIST
+```
+
+The frontend's filterable/sortable columns are all submission-owned, so the
+listing UX needs no DB-side joins — a clean two-query app-side join is enough.
+
+---
+
+## Open items
+
+- **biosim-client impact analysis.** The Python client at
+  `../biosim-client` (https://github.com/biosimulations/biosim-client) is an
+  external consumer of this platform's API surface and may be affected by
+  PR1's `BiosimSimulationRun` additions and PR3's listing reshape. Inventory →
+  diff → versioning/contract → consider monorepo absorption. See the TODO
+  section in [`simulation-runs-convergence-plan.md`](simulation-runs-convergence-plan.md);
+  do the inventory before PR3 lands.
+- **Hybrid status read for PR2.5.** Enrich
+  `GET /simulations/{processing_id}` to read `SimulationRunRecord`s for the
+  processing_id and fill `biosimulations_run_id` per job — small router change,
+  no contract change.
+- **No real auth.** Owner-scoped queries (`type=user` + `user=<email>`) trust
+  the supplied email today. Out of scope for the convergence work; flagged so
+  it doesn't get lost.


### PR DESCRIPTION
**PR2** of `docs/simulation-runs-convergence-plan.md`.

## Summary
The run path and the verify path each had their own implementation of "submit one sim to biosimulations.org → poll → save `BiosimulatorWorkflowRun`". This converges them: `SimulationRunWorkflow` now runs each simulator via a **child `OmexSimWorkflow`** — the same per-run unit `OmexVerifyWorkflow` already uses — and the duplicate `submit_simulation_activity` / `poll_simulation_activity` are deleted. The monolithic `submit_biosim_simulation_run_activity` becomes the single shared per-run implementation.

**Net:** −236/+100 lines; one orchestration unit and one submit/poll implementation; the verification production path is **untouched**.

## Deviation from the written plan (steps 1–2)
The plan called for *splitting* the activity so `OmexSimWorkflow` could surface `run_id` early. That turned out unnecessary and was skipped: **a Temporal parent cannot query a running child** (queries are client-side, not workflow-to-workflow), so "early run_id" would require a child→parent signal. Composing children with the **monolithic activity unchanged** is lower risk and still removes the duplication. The plan doc is updated to record this.

**Only behavior change:** `biosimulations_run_id` appears in the live `GET /simulations/{id}` status once a run **completes**, rather than right after submit. Untested/minor, and recoverable later via a child→parent signal if a use case needs it. The `/simulations/runs` listing is unaffected (it gets the id at completion either way).

## Testing
- `ruff` + `mypy --strict` clean.
- Simulations unit tests + `integration_local/test_simulations_run.py` (run path now executes through `OmexSimWorkflow` children) pass.
- Verify-path tests pass — confirmed untouched (PR2's diff is only `simulations/*`, `worker_main.py`, `temporal_fixtures.py`).
- Full `pytest -m "not integration"`: the only failures are the pre-existing `test_slurm_service` (SSH creds) and a **transient** real-network `simdata` 404 in `test_sim_workflow` (passed on retry; outside PR2's diff).

## Also
Adds a **TODO** in the plan doc to assess `biosim-client` (the external Python client for this platform's API) impact before PR3, and to consider absorbing it into the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)