### PR TITLE
Cleanup: four high-severity findings from PR #52 review

### DIFF
--- a/backend/biosim_server/biosim_omex/database.py
+++ b/backend/biosim_server/biosim_omex/database.py
@@ -33,6 +33,10 @@ class OmexDatabaseService(ABC):
     async def list_omex_files(self) -> list[OmexFile]:
         pass
 
+    async def ensure_indexes(self) -> None:
+        """Create or refresh indexes for the underlying store. Default: no-op."""
+        return
+
     @abstractmethod
     async def close(self) -> None:
         pass
@@ -99,6 +103,14 @@ class OmexDatabaseServiceMongo(OmexDatabaseService):
             del doc_dict["_id"]
             omex_files.append(OmexFile.model_validate(doc_dict))
         return omex_files
+
+    @override
+    async def ensure_indexes(self) -> None:
+        # Every get_omex_file / OMEX upload pipeline starts with a lookup by hash.
+        # Not declared unique here -- get_cached_omex_file_from_*'s check-then-insert
+        # pattern doesn't handle DuplicateKeyError, so a unique index would break the
+        # rare concurrent-upload race. Logical uniqueness is enforced by the caller.
+        await self._omex_file_col.create_index("file_hash_md5")
 
     @override
     async def close(self) -> None:

--- a/backend/biosim_server/biosim_runs/activities.py
+++ b/backend/biosim_server/biosim_runs/activities.py
@@ -158,12 +158,20 @@ async def submit_biosim_run_activity(input: SubmitBiosimRunActivityInput) -> Sub
         (_gcs_path, local_omex_path) = await file_service.download_file(gcs_path=input.omex_file.omex_gcs_path)
         activity.logger.info(
             f"Downloaded OMEX file from gcs_path {input.omex_file.omex_gcs_path} to local path {local_omex_path}")
-        simulation_run = await biosim_service.run_biosim_sim(
-            local_omex_path=local_omex_path,
-            omex_name=input.omex_file.uploaded_filename,
-            simulator_version=input.simulator_version,
-        )
-        os.remove(local_omex_path)
+        try:
+            simulation_run = await biosim_service.run_biosim_sim(
+                local_omex_path=local_omex_path,
+                omex_name=input.omex_file.uploaded_filename,
+                simulator_version=input.simulator_version,
+            )
+        finally:
+            # Always clean up the downloaded temp file -- even if run_biosim_sim raised
+            # (HTTP 5xx, network error, auth failure). Without this the worker pod
+            # accumulates orphaned files under sustained submit failures and ENOSPCs.
+            try:
+                os.remove(local_omex_path)
+            except OSError as e:
+                activity.logger.warning(f"Failed to remove local OMEX file {local_omex_path}: {e}")
         activity.logger.info(
             f"Submitted {input.simulator_version.id}:{input.simulator_version.version}, "
             f"biosimulations_run_id={simulation_run.id}")
@@ -233,9 +241,20 @@ async def poll_biosim_run_activity(input: PollBiosimRunActivityInput) -> Biosimu
             biosim_run=simulation_run,
             hdf5_file=hdf5_file)
 
-        saved = await database_service.insert_biosimulator_workflow_run(sim_workflow_run=biosim_workflow_run)
-        activity.logger.info(f"Saved BiosimulatorWorkflowRun _id={saved.database_id}")
-        return saved
+        # Only persist on SUCCEEDED. Caching non-SUCCEEDED rows pollutes BiosimSims
+        # (FAILED-status records accumulate per retry) and complicates cache lookup --
+        # get_biosimulator_workflow_runs returns up to 100 unsorted documents and the
+        # cache-hit check (`cached_runs[0].biosim_run.status == SUCCEEDED`) can miss a
+        # later SUCCEEDED row if a FAILED row was returned first. Returning the in-
+        # memory record (without database_id) still lets OmexSimWorkflow surface the
+        # FAILED state to its caller; the workflow doesn't consult database_id.
+        if simulation_run.status == BiosimSimulationRunStatus.SUCCEEDED:
+            saved = await database_service.insert_biosimulator_workflow_run(sim_workflow_run=biosim_workflow_run)
+            activity.logger.info(f"Saved BiosimulatorWorkflowRun _id={saved.database_id}")
+            return saved
+        activity.logger.info(
+            f"Skipping BiosimulatorWorkflowRun persist for non-SUCCEEDED status={simulation_run.status}")
+        return biosim_workflow_run
     except Exception as e:
         activity.logger.exception(f"Failed to poll biosim simulation run: {str(e)}", exc_info=e)
         raise e

--- a/backend/biosim_server/biosim_runs/database.py
+++ b/backend/biosim_server/biosim_runs/database.py
@@ -3,6 +3,7 @@ from abc import abstractmethod, ABC
 
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pymongo import ASCENDING
 from pymongo.results import InsertOneResult
 from typing_extensions import override
 
@@ -41,6 +42,10 @@ class DatabaseService(ABC):
     @abstractmethod
     async def delete_all_biosimulator_workflow_runs(self) -> None:
         pass
+
+    async def ensure_indexes(self) -> None:
+        """Create or refresh indexes for the underlying store. Default: no-op."""
+        return
 
     @abstractmethod
     async def close(self) -> None:
@@ -118,6 +123,18 @@ class DatabaseServiceMongo(DatabaseService):
         if not result.acknowledged:
             raise Exception("Delete failed")
 
+
+    @override
+    async def ensure_indexes(self) -> None:
+        # Cache lookup on every submit: (file_hash_md5, image_digest, cache_buster).
+        # biosim_run.id: used by get_biosimulator_workflow_runs_by_biosim_runid for
+        # the verify-by-existing-runs path and for any caller that resolves a run by id.
+        await self._sim_output_col.create_index([
+            ("file_hash_md5", ASCENDING),
+            ("image_digest", ASCENDING),
+            ("cache_buster", ASCENDING),
+        ])
+        await self._sim_output_col.create_index("biosim_run.id")
 
     @override
     async def close(self) -> None:

--- a/backend/biosim_server/dependencies.py
+++ b/backend/biosim_server/dependencies.py
@@ -108,9 +108,19 @@ async def init_standalone() -> None:
     from biosim_server.simulations.database import SimulationRunDatabaseServiceMongo
 
     motor_client = AsyncIOMotorClient(get_settings().mongodb_uri)
-    set_database_service(DatabaseServiceMongo(db_client=motor_client))
-    set_omex_database_service(OmexDatabaseServiceMongo(db_client=motor_client))
-    set_simulation_run_database_service(SimulationRunDatabaseServiceMongo(db_client=motor_client))
+    db_service = DatabaseServiceMongo(db_client=motor_client)
+    omex_db_service = OmexDatabaseServiceMongo(db_client=motor_client)
+    runs_db_service = SimulationRunDatabaseServiceMongo(db_client=motor_client)
+
+    # create_index is idempotent; calling on every start keeps schema in sync as
+    # we add lookups. Each service knows which fields its queries hit.
+    await db_service.ensure_indexes()
+    await omex_db_service.ensure_indexes()
+    await runs_db_service.ensure_indexes()
+
+    set_database_service(db_service)
+    set_omex_database_service(omex_db_service)
+    set_simulation_run_database_service(runs_db_service)
 
 async def shutdown_standalone() -> None:
     db_service = get_database_service()

--- a/backend/biosim_server/simulations/database.py
+++ b/backend/biosim_server/simulations/database.py
@@ -157,6 +157,10 @@ class SimulationRunDatabaseService(ABC):
     async def delete_all_simulation_runs(self) -> None:
         pass
 
+    async def ensure_indexes(self) -> None:
+        """Create or refresh indexes for the underlying store. Default: no-op."""
+        return
+
     @abstractmethod
     async def close(self) -> None:
         pass
@@ -245,6 +249,14 @@ class SimulationRunDatabaseServiceMongo(SimulationRunDatabaseService):
         result = await self._runs_col.delete_many({})
         if not result.acknowledged:
             raise Exception("Delete failed")
+
+    @override
+    async def ensure_indexes(self) -> None:
+        # processing_id: hot read on every GET /simulations/{id} hybrid-read.
+        # run_id: hot lookup on every early/terminal update_simulation_run call;
+        # also the natural primary key for a SimulationRunRecord.
+        await self._runs_col.create_index("processing_id")
+        await self._runs_col.create_index("run_id", unique=True)
 
     @override
     async def close(self) -> None:

--- a/backend/biosim_server/simulations/router.py
+++ b/backend/biosim_server/simulations/router.py
@@ -174,33 +174,65 @@ async def get_simulation_status(processing_id: str) -> ConglomerateStatus:
     if temporal_client is None:
         raise HTTPException(status_code=503, detail="Temporal service not available")
 
+    # Try the workflow query first. Don't 404 on failure -- the workflow's Temporal
+    # history may have been evicted while the SimulationRunRecord rows still exist
+    # in Mongo (the listing endpoint still surfaces them). Fall back to DB below.
+    status: ConglomerateStatus | None = None
     try:
         workflow_handle = temporal_client.get_workflow_handle(
             workflow_id=processing_id,
             result_type=ConglomerateStatus,
         )
-        status: ConglomerateStatus = await workflow_handle.query(
+        status = await workflow_handle.query(
             "get_status",
             result_type=ConglomerateStatus,
             rpc_timeout=timedelta(seconds=60),
         )
     except Exception as e:
-        msg = f"Error retrieving simulation status for id: {processing_id}: {e}"
-        logger.error(msg, exc_info=e)
-        raise HTTPException(status_code=404, detail=msg)
+        logger.info(f"Workflow query failed for {processing_id} (will try DB fallback): {e}")
 
-    # Hybrid read: the parent workflow's job_statuses only get biosimulations_run_id
-    # when each child completes. The child OmexSimWorkflow writes it to the
-    # SimulationRunRecord right after submit, so fill in any missing ids from the DB.
-    # Failures here are non-fatal -- we just return the workflow-only view.
+    # Fetch SimulationRunRecord rows for this processing_id once -- they enrich the
+    # workflow-query view with the early biosimulations_run_id, AND serve as the
+    # sole source when the workflow query failed above.
+    records: list[SimulationRunRecord] = []
     runs_db = get_simulation_run_database_service()
     if runs_db is not None:
         try:
             records = await runs_db.get_simulation_runs_by_processing_id(processing_id)
-            id_by_run = {r.run_id: r.biosimulations_run_id for r in records}
-            for job in status.jobs:
-                if job.biosimulations_run_id is None:
-                    job.biosimulations_run_id = id_by_run.get(job.job_id)
         except Exception as e:
-            logger.warning(f"Failed to enrich status from SimulationRunRecord: {e}")
-    return status
+            logger.warning(f"Failed to read SimulationRunRecords for {processing_id}: {e}")
+
+    if status is not None:
+        # Hybrid: workflow-query for live state, DB for the early run id per job.
+        id_by_run = {r.run_id: r.biosimulations_run_id for r in records}
+        for job in status.jobs:
+            if job.biosimulations_run_id is None:
+                job.biosimulations_run_id = id_by_run.get(job.job_id)
+        return status
+
+    if not records:
+        raise HTTPException(status_code=404, detail=f"Simulation run not found: {processing_id}")
+    return _conglomerate_status_from_records(processing_id, records)
+
+
+# Maps the SimulationRunRecord display status back onto the SimulationJobStatus
+# internal status. Inverse of job_status_to_display in simulations.models.
+_DISPLAY_TO_JOB_STATUS: dict[str, str] = {"CREATED": "processing", "SUCCEEDED": "success", "FAILED": "failure"}
+
+
+def _conglomerate_status_from_records(
+    processing_id: str, records: list[SimulationRunRecord]
+) -> ConglomerateStatus:
+    """Build a ConglomerateStatus from persisted records when the Temporal workflow
+    query is unavailable (history evicted, workflow never existed, Temporal down)."""
+    jobs = [
+        SimulationJobStatus(
+            job_id=record.run_id,
+            simulator_id=record.simulator,
+            version=record.simulator_version,
+            status=_DISPLAY_TO_JOB_STATUS.get(record.status, "processing"),
+            biosimulations_run_id=record.biosimulations_run_id,
+        )
+        for record in records
+    ]
+    return ConglomerateStatus(processing_id=processing_id, jobs=jobs)

--- a/backend/tests/fixtures/database_fixtures.py
+++ b/backend/tests/fixtures/database_fixtures.py
@@ -39,6 +39,7 @@ async def mongo_test_collection(mongo_test_database: AsyncIOMotorDatabase) -> As
 @pytest_asyncio.fixture(scope="function")
 async def database_service_mongo(mongo_test_client: AsyncIOMotorClient) -> AsyncGenerator[DatabaseServiceMongo,None]:
     db_service = DatabaseServiceMongo(db_client=mongo_test_client)
+    await db_service.ensure_indexes()
     old_db_service = get_database_service()
     set_database_service(db_service)
 
@@ -54,6 +55,7 @@ async def database_service_mongo(mongo_test_client: AsyncIOMotorClient) -> Async
 @pytest_asyncio.fixture(scope="function")
 async def omex_database_service_mongo(mongo_test_client: AsyncIOMotorClient) -> AsyncGenerator[OmexDatabaseServiceMongo,None]:
     omex_db_service = OmexDatabaseServiceMongo(db_client=mongo_test_client)
+    await omex_db_service.ensure_indexes()
     old_omex_db_service = get_omex_database_service()
     set_omex_database_service(omex_db_service)
 
@@ -68,6 +70,7 @@ async def simulation_run_database_service_mongo(
     mongo_test_client: AsyncIOMotorClient,
 ) -> AsyncGenerator[SimulationRunDatabaseServiceMongo, None]:
     runs_db_service = SimulationRunDatabaseServiceMongo(db_client=mongo_test_client)
+    await runs_db_service.ensure_indexes()
     old_runs_db_service = get_simulation_run_database_service()
     set_simulation_run_database_service(runs_db_service)
 

--- a/backend/tests/simulations/test_router.py
+++ b/backend/tests/simulations/test_router.py
@@ -355,7 +355,7 @@ def test_get_simulation_status_success(mock_get_temporal: MagicMock) -> None:
 
 @patch("biosim_server.simulations.router.get_temporal_client")
 def test_get_simulation_status_not_found(mock_get_temporal: MagicMock) -> None:
-    """Test 404 when workflow not found."""
+    """Test 404 when workflow not found AND no DB records exist."""
     temporal_client = MagicMock()
     workflow_handle = AsyncMock()
     workflow_handle.query.side_effect = Exception("Workflow not found")
@@ -366,6 +366,139 @@ def test_get_simulation_status_not_found(mock_get_temporal: MagicMock) -> None:
     response = client.get("/simulations/nonexistent")
 
     assert response.status_code == 404
+
+
+def _make_run_record(
+    run_id: str,
+    *,
+    processing_id: str,
+    status: str = "SUCCEEDED",
+    simulator: str = "copasi",
+    biosimulations_run_id: str | None = "biosim-abc",
+) -> object:
+    """Build a SimulationRunRecord for the fallback / hybrid-merge tests."""
+    from datetime import datetime, timezone
+
+    from biosim_server.simulations.models import SimulationRunRecord
+
+    when = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return SimulationRunRecord(
+        run_id=run_id,
+        processing_id=processing_id,
+        name="Run",
+        simulator=simulator,
+        simulator_version="4.34.251",
+        simulator_digest="sha256:abc",
+        cache_buster="0",
+        email="user@example.com",
+        status=status,  # type: ignore[arg-type]
+        biosimulations_run_id=biosimulations_run_id,
+        submitted=when,
+        updated=when,
+    )
+
+
+@patch("biosim_server.simulations.router.get_simulation_run_database_service")
+@patch("biosim_server.simulations.router.get_temporal_client")
+def test_get_simulation_status_falls_back_to_db_when_workflow_query_fails(
+    mock_get_temporal: MagicMock,
+    mock_get_runs_db: MagicMock,
+) -> None:
+    """If the workflow query fails (e.g. Temporal evicted the history), the endpoint
+    builds the response from persisted SimulationRunRecord rows instead of 404."""
+    temporal_client = MagicMock()
+    workflow_handle = AsyncMock()
+    workflow_handle.query.side_effect = Exception("workflow history evicted")
+    temporal_client.get_workflow_handle.return_value = workflow_handle
+    mock_get_temporal.return_value = temporal_client
+
+    runs_db = AsyncMock()
+    runs_db.get_simulation_runs_by_processing_id.return_value = [
+        _make_run_record("job-1", processing_id="sim-run-evicted", status="SUCCEEDED",
+                         simulator="copasi", biosimulations_run_id="biosim-1"),
+        _make_run_record("job-2", processing_id="sim-run-evicted", status="FAILED",
+                         simulator="tellurium", biosimulations_run_id="biosim-2"),
+    ]
+    mock_get_runs_db.return_value = runs_db
+
+    response = TestClient(app).get("/simulations/sim-run-evicted")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["processing_id"] == "sim-run-evicted"
+    assert len(data["jobs"]) == 2
+    # SUCCEEDED -> "success", FAILED -> "failure" via _DISPLAY_TO_JOB_STATUS.
+    by_id = {job["job_id"]: job for job in data["jobs"]}
+    assert by_id["job-1"]["status"] == "success"
+    assert by_id["job-1"]["biosimulations_run_id"] == "biosim-1"
+    assert by_id["job-2"]["status"] == "failure"
+    assert by_id["job-2"]["biosimulations_run_id"] == "biosim-2"
+
+
+@patch("biosim_server.simulations.router.get_simulation_run_database_service")
+@patch("biosim_server.simulations.router.get_temporal_client")
+def test_get_simulation_status_404_when_workflow_and_db_both_empty(
+    mock_get_temporal: MagicMock,
+    mock_get_runs_db: MagicMock,
+) -> None:
+    """If both the workflow query and the DB lookup come up empty, the endpoint 404s."""
+    temporal_client = MagicMock()
+    workflow_handle = AsyncMock()
+    workflow_handle.query.side_effect = Exception("workflow not found")
+    temporal_client.get_workflow_handle.return_value = workflow_handle
+    mock_get_temporal.return_value = temporal_client
+
+    runs_db = AsyncMock()
+    runs_db.get_simulation_runs_by_processing_id.return_value = []
+    mock_get_runs_db.return_value = runs_db
+
+    response = TestClient(app).get("/simulations/sim-run-unknown")
+
+    assert response.status_code == 404
+
+
+@patch("biosim_server.simulations.router.get_simulation_run_database_service")
+@patch("biosim_server.simulations.router.get_temporal_client")
+def test_get_simulation_status_hybrid_enriches_biosim_run_id_from_db(
+    mock_get_temporal: MagicMock,
+    mock_get_runs_db: MagicMock,
+) -> None:
+    """When the workflow query returns biosimulations_run_id=None for a job (mid-run
+    before the parent has copied it from children), the DB record's id fills in --
+    this is the PR2.5 early-write path made visible through GET /simulations/{id}."""
+    from biosim_server.simulations.models import ConglomerateStatus, SimulationJobStatus
+
+    workflow_status = ConglomerateStatus(
+        processing_id="sim-run-x",
+        jobs=[SimulationJobStatus(
+            job_id="job-1",
+            simulator_id="copasi",
+            version="4.34.251",
+            status="processing",
+            biosimulations_run_id=None,
+        )],
+    )
+    temporal_client = MagicMock()
+    workflow_handle = AsyncMock()
+    workflow_handle.query.return_value = workflow_status
+    temporal_client.get_workflow_handle.return_value = workflow_handle
+    mock_get_temporal.return_value = temporal_client
+
+    runs_db = AsyncMock()
+    runs_db.get_simulation_runs_by_processing_id.return_value = [
+        _make_run_record("job-1", processing_id="sim-run-x", status="CREATED",
+                         biosimulations_run_id="biosim-early"),
+    ]
+    mock_get_runs_db.return_value = runs_db
+
+    response = TestClient(app).get("/simulations/sim-run-x")
+
+    assert response.status_code == 200
+    job = response.json()["jobs"][0]
+    # Live status from the workflow query...
+    assert job["status"] == "processing"
+    # ...biosim_run_id enriched from the DB.
+    assert job["biosimulations_run_id"] == "biosim-early"
 
 
 def test_run_simulations_missing_fields() -> None:

--- a/docs/workflows-architecture.md
+++ b/docs/workflows-architecture.md
@@ -454,10 +454,80 @@ restructures are anticipated; not worth doing for PR2.5 alone.
   diff → versioning/contract → consider monorepo absorption. See the TODO
   section in [`simulation-runs-convergence-plan.md`](simulation-runs-convergence-plan.md);
   do the inventory before PR3 lands.
-- **Hybrid status read for PR2.5.** Enrich
-  `GET /simulations/{processing_id}` to read `SimulationRunRecord`s for the
-  processing_id and fill `biosimulations_run_id` per job — small router change,
-  no contract change.
 - **No real auth.** Owner-scoped queries (`type=user` + `user=<email>`) trust
   the supplied email today. Out of scope for the convergence work; flagged so
   it doesn't get lost.
+
+### Known issues from the PR #52 code review
+
+The high-severity findings (worker pod disk leak, FAILED-row cache pollution,
+missing Mongo indexes, status 404 after Temporal eviction) shipped in PR #53.
+These remain open — each has a tight fix; tackle them when convenient, or
+when one starts firing in production.
+
+#### Medium — fires under specific conditions
+
+- **#13 — Initial `get_sim_run` in `poll_biosim_run_activity` has no 404 handling.**
+  *Trigger:* biosimulations.org is eventually consistent; the Temporal task-queue
+  hop between submit and poll can land inside the consistency window.
+  *Impact:* A run biosimulations.org actually accepted hits 404 on the first
+  poll-side GET → activity raises → with `maximum_attempts=1` the whole run
+  is lost. New hazard introduced by the submit/poll split in PR #52 (the
+  monolithic activity reused the in-hand `simulation_run` and never made this
+  call).
+  *Fix:* short retry loop around the first `get_sim_run` on `ClientResponseError(404)`,
+  or a brief `workflow.sleep` before scheduling poll.
+
+- **#8 — `_submit` activity timeout reduced from 20 min to 5 min.** *Trigger:*
+  large OMEX archives over slow / contended uplinks. *Impact:* hard-fail on a
+  single slow upload with `maximum_attempts=1` and no retry — user has to
+  resubmit. Risk scales with OMEX size distribution. *Fix:* bump
+  `start_to_close_timeout` for `submit_biosim_run_activity`, or split GCS
+  download from biosimulations.org upload into two activities so each gets
+  its own budget.
+
+- **#6 — HDF5 retry last attempt re-raises 404 (off-by-one).** *Trigger:*
+  `simdata` API lag persists past the 10-retry window (~100 s) for a SUCCEEDED
+  run. *Impact:* poll activity raises → no `BiosimulatorWorkflowRun` saved →
+  next submission re-runs the simulator from scratch (no cache row). Pre-existing,
+  but the PR #52 split makes the wasted submit work more visible. *Fix:* on
+  the final attempt, log + record `hdf5_file=None` instead of re-raising; the
+  workflow still surfaces SUCCEEDED with degraded artifact metadata.
+
+#### Lower — rare or contained
+
+- **#7 — Cache hit returns `cached.workflow_id` verbatim.** Audit/traceability
+  confusion: a `BiosimulatorWorkflowRun` from a cache hit points at the prior
+  submission's workflow id, not the current one. Not user-visible. *Fix:* add
+  an explicit `is_cache_hit: bool` field on `BiosimulatorWorkflowRun` (or a
+  separate `cache_lookups` collection) so the original `workflow_id` is
+  preserved and reuse is observable.
+
+- **#15 — `update_simulation_run` always bumps `updated`.** Temporal replay of
+  `OmexSimWorkflow` can fire the early `update_run_status_activity` again with
+  the same `biosimulations_run_id` — every replay bumps `updated` even though
+  no field actually changes. Minor data noise; muddies any future "sort by
+  updated" UI. *Fix:* if the proposed `$set` would contain only `updated`,
+  skip the update.
+
+- **#11 — Lazy `ImportError` not caught by `except ActivityError`.** The lazy
+  `from biosim_server.simulations.activities import …` inside `OmexSimWorkflow.run`
+  isn't covered by the surrounding `except ActivityError`. A worker image that
+  excludes the `simulations` package (none today, but plausible if a verify-only
+  worker ever emerges) would abort the workflow on a path documented as
+  "non-fatal." *Fix:* widen the `except`, or pull the import to module top
+  (the cycle the lazy import guards against has since been re-evaluated — see
+  the simplify discussion in PR #52).
+
+- **#12 — `asyncio.gather(*, return_exceptions=True)` captures `CancelledError`.**
+  Operator-initiated cancellation of `SimulationRunWorkflow` (via `tctl workflow
+  cancel`) is mapped to `status="failure"` with an empty `error` and recorded
+  as FAILED in `SimulationRunRecord`. Affects manual ops only. *Fix:* re-raise
+  on `CancelledError` so cancellation propagates and the run is recorded as
+  cancelled (would also need a `CANCELLED` display status, or just no terminal
+  update).
+
+- **#9 — `get_simulation_runs_by_processing_id` caps at `length=100`.**
+  Submissions with >100 simulators silently lose enrichment past job 100.
+  Cap is well above any realistic submission today. *Fix:* `length=None` (or
+  match the workflow's job count exactly).


### PR DESCRIPTION
Follow-up to PR #52, addressing the four "High" findings from the code review (those that affect real production behavior).

## What's in
| Finding | Where | Fix |
|---|---|---|
| **#14** Worker pod disk leak (orphaned OMEX temp files when submit raises) | `biosim_runs/activities.py::submit_biosim_run_activity` | Wrap `biosim_service.run_biosim_sim` in `try/finally`; `os.remove` itself in `try/except OSError` so a missing-file race is non-fatal. |
| **#5** FAILED-row cache pollution + cache-lookup ordering hazard | `biosim_runs/activities.py::poll_biosim_run_activity` | Gate `insert_biosimulator_workflow_run` on `simulation_run.status == SUCCEEDED`. Activity still returns a fully-populated (un-saved) record so `OmexSimWorkflow` can surface the FAILED state — it doesn't consult `database_id`. |
| **#10** Missing Mongo indexes on hot lookups | three DB services + `init_standalone` + test fixtures | New `ensure_indexes()` method (default no-op on the abstract base, Mongo impls override). Called from `init_standalone()` and every test fixture. Indexes listed below. |
| **#2** Status endpoint 404s after Temporal history eviction even though `SimulationRunRecord` rows are still in Mongo | `simulations/router.py::get_simulation_status` | Don't immediately 404 on workflow-query failure — try the DB fallback. New `_conglomerate_status_from_records` helper builds a `ConglomerateStatus` from persisted rows (mapping `CREATED/SUCCEEDED/FAILED` back to `processing/success/failure`). Only 404 if both sources come up empty. |

## Indexes created (#10)
- `BiosimSimulationRuns`: `processing_id`, `run_id` (unique)
- `BiosimSims`: compound `(file_hash_md5, image_digest, cache_buster)` + `biosim_run.id`
- `BiosimOmex`: `file_hash_md5` (non-unique — `get_cached_omex_file_from_*`'s check-then-insert doesn't catch `DuplicateKeyError`, so logical uniqueness is enforced by the caller)

## Tests (#2)
Three new router tests:
- `test_get_simulation_status_falls_back_to_db_when_workflow_query_fails` — workflow raises, DB has 2 records (1 SUCCEEDED, 1 FAILED) → 200 with `success`/`failure` jobs and correct `biosim_run_id`s.
- `test_get_simulation_status_404_when_workflow_and_db_both_empty` — workflow raises, DB returns `[]` → 404.
- `test_get_simulation_status_hybrid_enriches_biosim_run_id_from_db` — workflow returns `biosim_run_id=None` mid-run, DB has the early-write value → response merges (live status from workflow, run id from DB).

Existing `test_get_simulation_status_not_found` still passes (no patched runs_db → falls back to None records → 404).

#5 doesn't have a dedicated unit test (the activity's deps are tied to module-global getters; the change is a 4-line guard whose behavior is obvious from inspection, and `integration_local` already exercises the SUCCEEDED path end-to-end). #14 and #10 are mechanical with the existing integration tests exercising the surrounding flows.

## Verification
- ruff + mypy --strict clean.
- Full `pytest -m "not integration"`: **83 passed, 1 failed** (the pre-existing `test_slurm_service` SSH-creds env test, unchanged through every PR in this stack).

## What's left
Medium and Lower findings from the review remain open (#6 HDF5 retry off-by-one, #7 stale `workflow_id` on cache hit, #8 submit timeout, #9 `length=100` cap, #11 ImportError, #12 `CancelledError`, #13 initial `get_sim_run` no 404 handling, #15 `updated` bump). #13 is the most "fires under normal conditions" of the medium group — biosimulations.org eventual consistency between submit and poll. Worth addressing next if you want to keep going.

🤖 Generated with [Claude Code](https://claude.com/claude-code)