### PR TITLE
Docs: post-PR #53 status + frontend wire-up reality on main

### DIFF
--- a/docs/simulation-runs-api-plan.md
+++ b/docs/simulation-runs-api-plan.md
@@ -1,14 +1,26 @@
-> **Status (2026-05-29): backend implemented.** `POST /simulations/runs` is live in
-> `backend/biosim_server/simulations/` — owner-scope (`type: all|user` + `user` email),
-> pagination, sorting, and filtering, returning `{ runs: SimulationRun[], pagination: { page, perPage, _total } }`.
-> Run records are persisted (collection `BiosimSimulationRuns`) on `POST /simulations/run`
-> and updated to `SUCCEEDED`/`FAILED` by `SimulationRunWorkflow`.
+> **Status (updated 2026-06-05): backend complete; frontend wire-up in progress on a
+> separate branch.** `POST /simulations/runs` is live in `backend/biosim_server/simulations/`
+> — owner-scope (`type: all|user` + `user` email), pagination, sorting, filtering — returning
+> `{ runs: SimulationRun[], pagination: { page, perPage, _total } }`. Run records are
+> persisted (collection `BiosimSimulationRuns`) on `POST /simulations/run` and updated to
+> `SUCCEEDED`/`FAILED` by `SimulationRunWorkflow`. Backend convergence work covered PR #48
+> through PR #53 (see `simulation-runs-convergence-plan.md`).
 >
 > **Deferred** (no source yet — returned as zero/empty): `cpus`, `memory`, `maxTime`,
-> `envVars`, `purpose`, `runtime`, `projectSize`, `resultsSize`. Real auth is not wired —
-> owner-scoping trusts the supplied email. **Frontend follow-up:** wire
-> `frontend/app/pages/simulations/index.vue` (currently mocked) to this endpoint;
-> read `runs` / `pagination._total` from the response.
+> `envVars`, `purpose`, `runtime`, `projectSize`, `resultsSize`. PR1 enriched
+> `BiosimSimulationRun` parsing so these are present on every saved `BiosimulatorWorkflowRun`;
+> PR3 (planned) will join them into the listing. Real auth is not wired — owner-scoping
+> trusts the supplied email.
+>
+> **Frontend follow-up status:** `frontend/app/pages/simulations/index.vue` on `main`
+> still renders hardcoded mock data via `setTimeout`. Harrison's branch
+> **`origin/feature/runs-page`** has a partial wire-up (calls `POST /simulations/runs`
+> with the right body shape; has a matching `frontend/app/models/filtering.ts`). The branch
+> is 18 commits behind `main` and has one response-shape bug — `fetched_data.value =
+> await $fetch(...)` assigns the whole response object to a `SimulationRun[]`-typed ref,
+> but the backend returns `{ runs, pagination }`. Fix is `fetched_data.value = response.runs`
+> with pagination tracked separately. Landing path (rebase vs surgical extraction) is a
+> coordination call; see memory `project_frontend_runs_branch`.
 
 ## To-Do:
 

--- a/docs/workflows-architecture.md
+++ b/docs/workflows-architecture.md
@@ -447,6 +447,20 @@ restructures are anticipated; not worth doing for PR2.5 alone.
 
 ## Open items
 
+- **Frontend listing wire-up not in `main`.** The `/simulations/runs` backend
+  endpoint is live (PR #48 → PR #53), but `frontend/app/pages/simulations/index.vue`
+  on `main` still renders hardcoded mock data via `setTimeout`. The remote branch
+  **`origin/feature/runs-page`** (Harrison) has a partial wire-up — `$fetch` to
+  `POST ${api_url}/simulations/runs` with the correct `{type, user, sort, filters,
+  pagination}` body and a matching `frontend/app/models/filtering.ts`. The branch
+  is 18 commits behind `main`, contains substantial unrelated drift (other pages,
+  `poetry.lock` regen), and has **one response-shape bug** — line ~228 does
+  `fetched_data.value = await $fetch(...)` (assigns the whole response object to
+  a `SimulationRun[]`-typed ref), but the backend returns `{ runs: SimulationRun[],
+  pagination: {…} }`. The table will render empty until that's changed to
+  `fetched_data.value = response.runs` with `pagination._total` tracked separately.
+  Landing path is a coordination question (rebase Harrison's branch vs surgical
+  extraction); see the memory `project_frontend_runs_branch` for current status.
 - **biosim-client impact analysis.** The Python client at
   `../biosim-client` (https://github.com/biosimulations/biosim-client) is an
   external consumer of this platform's API surface and may be affected by

--- a/docs/workflows-architecture.md
+++ b/docs/workflows-architecture.md
@@ -143,7 +143,7 @@ The duplication was the core liability: two implementations of the same logic
 (cache lookup, HTTP submit, polling loop, HDF5-404 retry, BiosimulatorWorkflowRun
 insertion) drifting against each other.
 
-### Shape B — PR2 / [#51](https://github.com/biosimulations/platform/pull/51) (open)
+### Shape B — PR2 / [#51](https://github.com/biosimulations/platform/pull/51) (merged)
 
 `SimulationRunWorkflow` now runs each simulator via a child **`OmexSimWorkflow`** —
 the same per-run unit the verify path uses. The duplicate
@@ -236,10 +236,10 @@ flowchart LR
     URS -- "write biosim_run_id (EARLY)" --> DBR
     OSW -- "3. execute" --> POLL
     POLL -- "HTTP poll + HDF5" --> EXT
-    POLL -- "write result" --> DB_SIMS
+    POLL -- "write (SUCCEEDED only, since PR #53)" --> DB_SIMS
     SRW -- "after children complete" --> URS
-    EPS -- "query workflow (status)<br/>+ read DBR (biosim_run_id)" --> SRW
-    EPS -- "(DB read)" --> DBR
+    EPS -- "query workflow (live status)" --> SRW
+    EPS -- "DB enrich (run_id) / DB fallback when workflow query fails, since PR #53" --> DBR
 ```
 
 Key properties:
@@ -247,10 +247,16 @@ Key properties:
   UUID = `SimulationRunRecord.run_id`). The verify path passes `None` →
   step 2 above is skipped → **zero behavior change to verification**.
 - The status endpoint becomes a hybrid read: workflow query for live status,
-  DB record for run_id (and any other submission metadata).
+  DB record for run_id (and any other submission metadata). Since PR #53 it
+  also falls back to a DB-only response when the workflow query fails (history
+  evicted, workflow never existed), and only 404s when both sources are empty.
 - The monolithic activity is replaced by the split pair; `OmexSimWorkflow`,
   `OmexVerifyWorkflow`, and `SimulationRunWorkflow` all benefit from the cleaner
   decomposition.
+- Since PR #53, `poll_biosim_run_activity` only inserts `BiosimulatorWorkflowRun`
+  into `BiosimSims` on `SUCCEEDED`. FAILED / RUN_ID_NOT_FOUND runs return an
+  un-saved record so `OmexSimWorkflow` can still surface the failure, but the
+  cache table stays clean.
 
 ### Sequence — the run lifecycle after PR2.5
 
@@ -288,7 +294,11 @@ sequenceDiagram
         OSW->>POLL: execute poll (run_id)
         POLL->>EXT: GET /runs/{id} (poll until terminal)
         POLL->>EXT: GET HDF5 metadata
-        POLL->>DBS: insert BiosimulatorWorkflowRun
+        alt SUCCEEDED (since PR #53)
+            POLL->>DBS: insert BiosimulatorWorkflowRun
+        else FAILED / RUN_ID_NOT_FOUND
+            Note over POLL,DBS: insert skipped — record returned to workflow only
+        end
         POLL-->>OSW: full record
         OSW-->>SRW: OmexSimWorkflowOutput (status, run record)
     end
@@ -298,18 +308,24 @@ sequenceDiagram
 
     loop polling
         U->>API: GET /simulations/{processing_id}
-        API->>SRW: query get_status
-        API->>DBR: read run_ids by processing_id
-        API-->>U: ConglomerateStatus (status from workflow, run_ids from DB)
+        alt workflow query succeeds
+            API->>SRW: query get_status
+            API->>DBR: read run_ids by processing_id (enrichment)
+            API-->>U: ConglomerateStatus (status from workflow, run_ids from DB)
+        else workflow not found / history evicted (since PR #53)
+            API->>DBR: read all records by processing_id
+            alt records exist
+                API-->>U: ConglomerateStatus (built from DB records)
+            else no records
+                API-->>U: 404
+            end
+        end
     end
 
     U->>API: POST /simulations/runs (listing query)
     API->>DBR: filter/sort/paginate
     API-->>U: { runs[], pagination }
 ```
-
-Steps 4–6 (the early DB write) and step 12 (hybrid status read) are the PR2.5
-delta. Everything above the dashed band is in #51 today.
 
 ---
 
@@ -359,6 +375,10 @@ Two intentional choices to call out:
 1. **`BiosimSims` is a deduplicated *computation/artifact* table.** With caching
    on, many submissions of the same `(omex, simulator, cache_buster)` map to
    one `BiosimulatorWorkflowRun`. That's the result-provenance + cache role.
+   Since PR #53, only `SUCCEEDED` runs are persisted here — FAILED and
+   `RUN_ID_NOT_FOUND` results are surfaced to the workflow but never written,
+   so the cache stays clean and the lookup-first-match semantics don't fight
+   each other.
 2. **`BiosimSimulationRuns` is the *submission ledger.*** One per user action,
    even on a cache hit. It carries identity (`email`, user-chosen `name`,
    `purpose`), submission timestamps, and a *display* status

--- a/docs/workflows-architecture.md
+++ b/docs/workflows-architecture.md
@@ -294,10 +294,10 @@ sequenceDiagram
         OSW->>POLL: execute poll (run_id)
         POLL->>EXT: GET /runs/{id} (poll until terminal)
         POLL->>EXT: GET HDF5 metadata
-        alt SUCCEEDED (since PR #53)
+        alt SUCCEEDED only
             POLL->>DBS: insert BiosimulatorWorkflowRun
         else FAILED / RUN_ID_NOT_FOUND
-            Note over POLL,DBS: insert skipped — record returned to workflow only
+            Note over POLL,DBS: insert skipped (PR53) — record returned to workflow only
         end
         POLL-->>OSW: full record
         OSW-->>SRW: OmexSimWorkflowOutput (status, run record)
@@ -312,7 +312,7 @@ sequenceDiagram
             API->>SRW: query get_status
             API->>DBR: read run_ids by processing_id (enrichment)
             API-->>U: ConglomerateStatus (status from workflow, run_ids from DB)
-        else workflow not found / history evicted (since PR #53)
+        else workflow not found / history evicted
             API->>DBR: read all records by processing_id
             alt records exist
                 API-->>U: ConglomerateStatus (built from DB records)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -107,9 +107,9 @@ Backend endpoints consumed (see `../backend/CLAUDE.md` for the full list):
 
 | Page | Calls |
 |------|-------|
-| `pages/simulations/run.vue` | `POST /compatibility/check`, `POST /simulations/run` |
-| `pages/simulations/check-status/[processing_id].vue` | `GET /simulations/{processing_id}` |
-| `pages/simulations/index.vue` | `GET /runs` (currently commented out) |
+| `pages/simulations/run.vue` | `POST /compatibility/check`, `POST /simulations/run` (optional `cache_buster`) |
+| `pages/simulations/check-status/[processing_id].vue` | `GET /simulations/{processing_id}` (workflow-query + DB-fallback hybrid, since PR #53) |
+| `pages/simulations/index.vue` | `POST /simulations/runs` — **not wired on `main`** (renders hardcoded mock data via `setTimeout`); partial wire-up exists on remote branch `origin/feature/runs-page` with a known response-shape bug. See `docs/simulation-runs-api-plan.md` for the status. |
 | `pages/biosim-db.vue` | `GET /projects` (against `runtimeConfig.public.biosimulations_api_url` — the public biosimulations.org project DB API, not the platform backend) |
 
 ## Key Patterns


### PR DESCRIPTION
Doc-only follow-up after the PR #48–#53 stack landed. Three docs were drifting and now name what's actually true on \`main\`.

## What changed

- **\`docs/workflows-architecture.md\`** "Open items" leads with the frontend listing wire-up status:
  - backend \`POST /simulations/runs\` is live (PR #48 → #53)
  - \`frontend/app/pages/simulations/index.vue\` on \`main\` still renders hardcoded mock data via \`setTimeout\`
  - Harrison's partial wire-up exists on remote branch \`origin/feature/runs-page\` (18 commits behind \`main\`) with a known response-shape bug — assigns the whole \`{ runs, pagination }\` response to a \`SimulationRun[]\`-typed ref
  - Landing is a coordination decision (rebase Harrison's branch vs surgical extraction)

- **\`docs/simulation-runs-api-plan.md\`** status banner now describes the full convergence (PR #48–#53) as backend-complete, the frontend follow-up as partial-on-a-separate-branch with the same known bug, and points readers to the architecture doc / memory for the coordination decision.

- **\`frontend/CLAUDE.md\`** "Backend API Integration" table row for \`index.vue\` was stale (\`GET /runs (currently commented out)\` — wrong path, wrong method, wrong state). Now lists \`POST /simulations/runs\` with the actual state.

## Out of scope (intentionally)

This is a status-truth-up update, not a content-shift. The PR3 plan, the biosim-client TODO, the known-issues catalog from the PR #52 review, and the worker-drain deploy callout (all already in \`docs/\`) are unchanged.

## Not in this PR

Two memory files were updated in parallel (\`~/.claude/projects/.../memory/project_simulations_endpoint.md\` rewritten for post-#53 state; new \`project_frontend_runs_branch.md\`) — those live on Jim's machine, not in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)