### PR TITLE
Fix title casing: biosimulations platform → BioSimulations platform

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "upload_type": "software",
-  "title": "biosimulations platform",
+  "title": "BioSimulations platform",
   "license": "mit",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using these metadata."
-title: "biosimulations platform"
+title: "BioSimulations platform"
 type: software
 repository-code: "https://github.com/biosimulations/platform"
 license: MIT


### PR DESCRIPTION
Aligns the `.zenodo.json` and `CITATION.cff` titles with the published Zenodo record, which displays **BioSimulations platform** — both files had the lowercased `biosimulations platform`.

Because release archiving uses `.zenodo.json` verbatim, the next release would have **regressed** the published title. Updating both files keeps them consistent and prevents a `cffconvert` regen from reintroducing the lowercase form.

Surfaced by `zenodo-maint audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZx7w9BexQc9wWU5JoHYaF