### PR TITLE
Add project search API (GET /projects, /projects/stats)

### DIFF
--- a/backend/biosim_server/api/main.py
+++ b/backend/biosim_server/api/main.py
@@ -17,6 +17,7 @@ from biosim_server.biosim_runs import BiosimulatorVersion
 from biosim_server.biosim_verify import CompareSettings
 from biosim_server.compatibility import compatibility_router
 from biosim_server.simulations import simulations_router
+from biosim_server.projects import projects_router
 from biosim_server.biosim_verify.models import VerifyWorkflowOutput, VerifyWorkflowStatus
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow, OmexVerifyWorkflowInput
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflowInput, RunsVerifyWorkflow
@@ -112,6 +113,7 @@ app.add_middleware(
 # include routers
 app.include_router(compatibility_router)
 app.include_router(simulations_router)
+app.include_router(projects_router)
 
 
 # -- endpoint logic -- #

--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -45,6 +45,14 @@ class Settings(BaseSettings):
     mongodb_collection_sims: str = "BiosimSims"
     mongodb_collection_compare: str = "BiosimCompare"
     mongodb_collection_simulation_runs: str = "BiosimSimulationRuns"
+    mongodb_collection_projects: str = "Projects"
+    mongodb_collection_metadata: str = "Metadata"
+    mongodb_collection_specifications: str = "Specifications"
+    # Legacy pre-2022 materialized summary; dead/abandoned (nothing writes it).
+    # Kept only for reference — the API assembles from Projects + Metadata live.
+    mongodb_collection_project_summary: str = "projectSummary"
+    # TTL (seconds) for the platform-owned facet-stats cache.
+    project_stats_cache_ttl_seconds: int = 300
 
     simdata_api_base_url: str = "https://simdata.api.biosimulations.org"
     biosimulators_api_base_url: str = "https://api.biosimulators.org"

--- a/backend/biosim_server/dependencies.py
+++ b/backend/biosim_server/dependencies.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     # Imported lazily at runtime (see init_standalone) to avoid an import cycle:
     # simulations/__init__.py -> router -> dependencies.
     from biosim_server.simulations.database import SimulationRunDatabaseService
+    from biosim_server.projects.database import ProjectDatabaseService
 
 #------ file service (standalone or pytest) ------
 
@@ -62,6 +63,18 @@ def get_simulation_run_database_service() -> "SimulationRunDatabaseService | Non
     global global_simulation_run_database_service
     return global_simulation_run_database_service
 
+#------- project database service (standalone or pytest) ------
+
+global_project_database_service: "ProjectDatabaseService | None" = None
+
+def set_project_database_service(service: "ProjectDatabaseService | None") -> None:
+    global global_project_database_service
+    global_project_database_service = service
+
+def get_project_database_service() -> "ProjectDatabaseService | None":
+    global global_project_database_service
+    return global_project_database_service
+
 #------- biosim service (standalone or pytest) ------
 
 global_biosim_service: BiosimService | None = None
@@ -106,21 +119,25 @@ async def init_standalone() -> None:
 
     # Local import avoids the simulations -> dependencies import cycle at module load.
     from biosim_server.simulations.database import SimulationRunDatabaseServiceMongo
+    from biosim_server.projects.database import ProjectDatabaseServiceMongo
 
     motor_client = AsyncIOMotorClient(get_settings().mongodb_uri)
     db_service = DatabaseServiceMongo(db_client=motor_client)
     omex_db_service = OmexDatabaseServiceMongo(db_client=motor_client)
     runs_db_service = SimulationRunDatabaseServiceMongo(db_client=motor_client)
+    projects_db_service = ProjectDatabaseServiceMongo(db_client=motor_client)
 
     # create_index is idempotent; calling on every start keeps schema in sync as
     # we add lookups. Each service knows which fields its queries hit.
     await db_service.ensure_indexes()
     await omex_db_service.ensure_indexes()
     await runs_db_service.ensure_indexes()
+    await projects_db_service.ensure_indexes()
 
     set_database_service(db_service)
     set_omex_database_service(omex_db_service)
     set_simulation_run_database_service(runs_db_service)
+    set_project_database_service(projects_db_service)
 
 async def shutdown_standalone() -> None:
     db_service = get_database_service()
@@ -139,5 +156,6 @@ async def shutdown_standalone() -> None:
     set_biosim_service(None)
     set_temporal_client(None)
     set_database_service(None)
-    # Shares the motor client closed via db_service above; just clear the handle.
+    # Shares the motor client closed via db_service above; just clear the handles.
     set_simulation_run_database_service(None)
+    set_project_database_service(None)

--- a/backend/biosim_server/projects/__init__.py
+++ b/backend/biosim_server/projects/__init__.py
@@ -1,0 +1,25 @@
+from biosim_server.projects.database import (
+    ProjectDatabaseService,
+    ProjectDatabaseServiceMongo,
+    build_match_stage,
+)
+from biosim_server.projects.models import (
+    ProjectQueryStat,
+    ProjectSearchFilter,
+    ProjectStub,
+    ProjectStubPage,
+    ValueFrequency,
+)
+from biosim_server.projects.router import router as projects_router
+
+__all__ = [
+    "ProjectDatabaseService",
+    "ProjectDatabaseServiceMongo",
+    "build_match_stage",
+    "ProjectQueryStat",
+    "ProjectSearchFilter",
+    "ProjectStub",
+    "ProjectStubPage",
+    "ValueFrequency",
+    "projects_router",
+]

--- a/backend/biosim_server/projects/database.py
+++ b/backend/biosim_server/projects/database.py
@@ -1,0 +1,376 @@
+"""Async persistence for the BioSim DB project search API.
+
+Assembles project summaries live from the authoritative ``Projects`` collection
+joined to per-run ``Metadata`` (keyed by ``simulationRun``) in
+``biosimulations-prod`` — the same live-assembly the biosimulations API does,
+covering all published projects and always current.
+
+NOT used: the ``projectSummary`` collection is a dead pre-2022 materialization
+(subset, frozen, nothing writes it). See ``docs/project-search-api-plan.md``.
+
+Facet stats (a full scan of the matched set) are cached in a platform-owned,
+in-process TTL cache so paging stays cheap. All DB access lives behind the
+``ProjectDatabaseService`` ABC. Pagination is 1-indexed and computed in Mongo
+(``$skip``/``$limit`` + a real count via ``$facet``), fixing the legacy
+``summary_filtered`` bug where totals and page windows disagreed past page 1.
+"""
+
+import logging
+import re
+import time
+from abc import ABC, abstractmethod
+from typing import Any
+from urllib.parse import quote
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from typing_extensions import override
+
+from biosim_server.config import get_settings
+from biosim_server.projects.models import (
+    ProjectQueryStat,
+    ProjectSearchFilter,
+    ProjectStub,
+    ValueFrequency,
+)
+
+logger = logging.getLogger(__name__)
+
+# Facet target -> field name inside a metadata item. Each resolver pulls the set
+# of string values a project carries for that target; used for both filtering and
+# facet counts. Kept small on purpose for the first cut — model format / simulator
+# need a Specifications join and land later.
+_FACET_TARGETS: dict[str, str] = {
+    "taxa": "taxa",
+    "keywords": "keywords",
+}
+
+# metadata fields searched by `searchTerm` (case-insensitive substring).
+_SEARCH_FIELDS = ("title", "abstract", "description")
+
+# The first metadata item of the joined Metadata doc is surfaced as `_meta0` by
+# the aggregation; all match/project expressions reference that. The joined
+# Specifications models (for model_format) are surfaced as `_models`.
+_META = "_meta0"
+_MODELS = "_models"
+
+
+def _iso(value: Any) -> str:
+    """ISO-8601 with trailing Z for UTC, matching the frontend date format."""
+    if hasattr(value, "isoformat"):
+        return str(value.isoformat()).replace("+00:00", "Z")
+    return str(value or "")
+
+
+def _label_values(raw: Any) -> list[str]:
+    """Normalize a metadata field to a flat list of string values.
+
+    Handles both plain strings and ``{uri, label}`` objects (taxa, keywords,
+    encodes, ... are stored either way across records)."""
+    values: list[str] = []
+    if not isinstance(raw, list):
+        return values
+    for item in raw:
+        if isinstance(item, str):
+            if item:
+                values.append(item)
+        elif isinstance(item, dict):
+            label = item.get("label")
+            if isinstance(label, str) and label:
+                values.append(label)
+    return values
+
+
+def _search_clause(search_term: str) -> dict[str, Any]:
+    """Case-insensitive substring match across the searched metadata fields."""
+    pattern = {"$regex": re.escape(search_term), "$options": "i"}
+    return {"$or": [{f"{_META}.{field}": pattern} for field in _SEARCH_FIELDS]}
+
+
+def _filter_clauses(filters: list[ProjectSearchFilter]) -> list[dict[str, Any]]:
+    """Translate active filters into Mongo clauses (AND across targets,
+    OR within a target's allowable_values). Skips unknown/empty targets."""
+    clauses: list[dict[str, Any]] = []
+    for f in filters:
+        field = _FACET_TARGETS.get(f.target)
+        if field is None or not f.allowable_values:
+            continue
+        # Value may be stored as a bare string or as {label}; match either.
+        clauses.append(
+            {
+                "$or": [
+                    {f"{_META}.{field}": {"$in": f.allowable_values}},
+                    {f"{_META}.{field}.label": {"$in": f.allowable_values}},
+                ]
+            }
+        )
+    return clauses
+
+
+def build_match_stage(
+    filters: list[ProjectSearchFilter], search_term: str
+) -> dict[str, Any] | None:
+    """Assemble the ``$match`` (over joined metadata) for filters + free text.
+
+    Returns ``None`` when there is nothing to match (no filters, no search)."""
+    and_clauses: list[dict[str, Any]] = _filter_clauses(filters)
+    if search_term:
+        and_clauses.append(_search_clause(search_term))
+    if not and_clauses:
+        return None
+    if len(and_clauses) == 1:
+        return and_clauses[0]
+    return {"$and": and_clauses}
+
+
+def _join_stages(metadata_collection: str) -> list[dict[str, Any]]:
+    """Join each Project to the first metadata item of its run's Metadata doc,
+    surfaced as ``_meta0`` (``{}`` when the run has no Metadata)."""
+    return [
+        {
+            "$lookup": {
+                "from": metadata_collection,
+                "localField": "simulationRun",
+                "foreignField": "simulationRun",
+                "as": "_md",
+            }
+        },
+        {"$addFields": {"_mddoc": {"$arrayElemAt": ["$_md", 0]}}},
+        {
+            "$addFields": {
+                _META: {
+                    "$ifNull": [
+                        {"$arrayElemAt": [{"$ifNull": ["$_mddoc.metadata", []]}, 0]},
+                        {},
+                    ]
+                }
+            }
+        },
+    ]
+
+
+def _format_from_language_urn(urn: Any) -> str:
+    """Map a SED-ML model-language URN to a short format label.
+
+    ``urn:sedml:language:sbml.level-2.version-3`` -> ``SBML``;
+    ``urn:sedml:language:cellml.1_0`` -> ``CELLML``."""
+    if not isinstance(urn, str) or not urn:
+        return ""
+    tail = urn.split(":")[-1]        # sbml.level-2.version-3
+    base = tail.split(".")[0]        # sbml
+    return base.upper()
+
+
+def _model_format(models: Any) -> str:
+    """First non-empty model-language label across a run's SED-ML models."""
+    if not isinstance(models, list):
+        return ""
+    for model in models:
+        if isinstance(model, dict):
+            label = _format_from_language_urn(model.get("language"))
+            if label:
+                return label
+    return ""
+
+
+def _image_url(run: str, thumbnails: Any, api_base: str) -> str | None:
+    """Resolve the first thumbnail to a URL.
+
+    Absolute URLs pass through; a bare archive filename becomes the
+    biosimulations file-download endpoint (verified 200 for a `browse`
+    thumbnail): ``{api}/files/{run}/{file}/download/?thumbnail=browse``."""
+    if not isinstance(thumbnails, list) or not thumbnails:
+        return None
+    first = thumbnails[0]
+    if not isinstance(first, str) or not first:
+        return None
+    if first.startswith("http://") or first.startswith("https://"):
+        return first
+    if not run:
+        return None
+    return f"{api_base}/files/{run}/{quote(first, safe='')}/download/?thumbnail=browse"
+
+
+def _stub_from_agg(doc: dict[str, Any], api_base: str) -> ProjectStub:
+    meta = doc.get(_META) or {}
+    run = str(doc.get("simulationRun", ""))
+    summary = meta.get("abstract") or meta.get("description") or ""
+    return ProjectStub(
+        id=str(doc.get("id", "")),
+        simulation_run=run,
+        created=_iso(doc.get("created")),
+        updated=_iso(doc.get("updated")),
+        name=str(meta.get("title") or doc.get("id", "")),
+        summary=str(summary),
+        model_format=_model_format(doc.get(_MODELS)),
+        image_url=_image_url(run, meta.get("thumbnails"), api_base),
+    )
+
+
+class ProjectDatabaseService(ABC):
+    @abstractmethod
+    async def query_project_stubs(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        filters: list[ProjectSearchFilter],
+        search_term: str,
+    ) -> tuple[list[ProjectStub], int]:
+        """Return a page of matching project stubs and the total match count."""
+
+    @abstractmethod
+    async def query_project_stats(
+        self, *, filters: list[ProjectSearchFilter], search_term: str
+    ) -> list[ProjectQueryStat]:
+        """Return facet counts (tags/categories) for the current query."""
+
+    async def ensure_indexes(self) -> None:
+        """Create or refresh indexes. Default: no-op (read-only source)."""
+        return
+
+    @abstractmethod
+    async def close(self) -> None:
+        pass
+
+
+class _TtlCache:
+    """Tiny in-process TTL cache. Platform-owned so paging never triggers a full
+    facet rescan; decoupled from any external cache/collection."""
+
+    def __init__(self, ttl_seconds: float) -> None:
+        self._ttl = ttl_seconds
+        self._store: dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if time.monotonic() >= expires_at:
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = (time.monotonic() + self._ttl, value)
+
+
+class ProjectDatabaseServiceMongo(ProjectDatabaseService):
+    _db_client: AsyncIOMotorClient
+    _projects_col: AsyncIOMotorCollection
+    _metadata_collection_name: str
+
+    def __init__(self, db_client: AsyncIOMotorClient) -> None:
+        settings = get_settings()
+        self._db_client = db_client
+        database = self._db_client.get_database(settings.mongodb_database)
+        self._projects_col = database.get_collection(settings.mongodb_collection_projects)
+        self._metadata_collection_name = settings.mongodb_collection_metadata
+        self._specifications_collection_name = settings.mongodb_collection_specifications
+        self._api_base = settings.biosimulations_api_base_url.rstrip("/")
+        self._stats_cache = _TtlCache(settings.project_stats_cache_ttl_seconds)
+
+    def _pipeline_prefix(
+        self, filters: list[ProjectSearchFilter], search_term: str
+    ) -> list[dict[str, Any]]:
+        stages = _join_stages(self._metadata_collection_name)
+        match = build_match_stage(filters, search_term)
+        if match is not None:
+            stages.append({"$match": match})
+        return stages
+
+    @override
+    async def query_project_stubs(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        filters: list[ProjectSearchFilter],
+        search_term: str,
+    ) -> tuple[list[ProjectStub], int]:
+        page = max(page, 1)
+        per_page = max(per_page, 1)
+        skip = (page - 1) * per_page
+
+        pipeline = self._pipeline_prefix(filters, search_term)
+        pipeline.append(
+            {
+                "$facet": {
+                    # The Specifications join (for model_format) is scoped INSIDE
+                    # this sub-pipeline, after $skip/$limit, so it resolves specs
+                    # only for the ~per_page items on the page, not every match.
+                    "items": [
+                        {"$sort": {"updated": -1, "id": 1}},
+                        {"$skip": skip},
+                        {"$limit": per_page},
+                        {
+                            "$lookup": {
+                                "from": self._specifications_collection_name,
+                                "localField": "simulationRun",
+                                "foreignField": "simulationRun",
+                                "as": "_spec",
+                            }
+                        },
+                        {
+                            "$addFields": {
+                                _MODELS: {
+                                    "$ifNull": [{"$arrayElemAt": ["$_spec.models", 0]}, []]
+                                }
+                            }
+                        },
+                        {
+                            "$project": {
+                                "id": 1,
+                                "simulationRun": 1,
+                                "created": 1,
+                                "updated": 1,
+                                _META: 1,
+                                _MODELS: 1,
+                            }
+                        },
+                    ],
+                    "total": [{"$count": "n"}],
+                }
+            }
+        )
+        result = await self._projects_col.aggregate(pipeline).to_list(length=1)
+        if not result:
+            return [], 0
+        facet = result[0]
+        stubs = [_stub_from_agg(dict(doc), self._api_base) for doc in facet.get("items", [])]
+        total_list = facet.get("total", [])
+        total = int(total_list[0]["n"]) if total_list else 0
+        return stubs, total
+
+    @override
+    async def query_project_stats(
+        self, *, filters: list[ProjectSearchFilter], search_term: str
+    ) -> list[ProjectQueryStat]:
+        cache_key = repr((sorted((f.target, tuple(f.allowable_values)) for f in filters), search_term))
+        cached = self._stats_cache.get(cache_key)
+        if cached is not None:
+            return list(cached)
+
+        pipeline = self._pipeline_prefix(filters, search_term)
+        pipeline.append({"$project": {_META: 1}})
+
+        counts: dict[str, dict[str, int]] = {t: {} for t in _FACET_TARGETS}
+        async for doc in self._projects_col.aggregate(pipeline):
+            meta = dict(doc).get(_META) or {}
+            for target, field in _FACET_TARGETS.items():
+                for value in _label_values(meta.get(field)):
+                    counts[target][value] = counts[target].get(value, 0) + 1
+
+        stats: list[ProjectQueryStat] = []
+        for target, freqs in counts.items():
+            value_frequencies = [
+                ValueFrequency(value=v, count=c)
+                for v, c in sorted(freqs.items(), key=lambda kv: kv[1], reverse=True)
+            ]
+            stats.append(ProjectQueryStat(target=target, value_frequencies=value_frequencies))
+        self._stats_cache.set(cache_key, stats)
+        return stats
+
+    @override
+    async def close(self) -> None:
+        self._db_client.close()

--- a/backend/biosim_server/projects/models.py
+++ b/backend/biosim_server/projects/models.py
@@ -1,0 +1,67 @@
+"""Models for the BioSim DB project search API.
+
+Backs the two GET endpoints that replace the legacy
+``/projects/summary_filtered`` (see ``docs/project-search-api-plan.md``):
+
+- ``GET /projects``        -> paginated slim ``ProjectStub`` results
+- ``GET /projects/stats``  -> tag/category facet counts (``ProjectQueryStat``)
+
+Field names mirror ``frontend/app/models/projects.ts`` so the frontend types do
+not drift.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ValueFrequency(BaseModel):
+    """One facet value and how many matching projects carry it."""
+
+    value: str
+    count: int
+
+
+class ProjectQueryStat(BaseModel):
+    """Facet counts for a single filterable target (e.g. taxa, modelFormat)."""
+
+    target: str
+    value_frequencies: list[ValueFrequency] = Field(
+        default_factory=list, serialization_alias="valueFrequencies"
+    )
+
+
+class ProjectSearchFilter(BaseModel):
+    """One active filter: restrict ``target`` to any of ``allowable_values``.
+
+    Matches the frontend ``ProjectSearchFilter`` interface. Sent to the API as a
+    JSON-encoded array in the ``filters`` query param.
+    """
+
+    target: str
+    allowable_values: list[str] = Field(default_factory=list)
+
+
+class ProjectStub(BaseModel):
+    """Slim, list-optimized project record. Mirrors the frontend ``ProjectStub``.
+
+    ``model_format`` and ``image_url`` require a join beyond ``projectSummary``
+    (Specifications / Files) and are best-effort until that join lands; they
+    default to empty rather than failing the whole page.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    simulation_run: str = Field(serialization_alias="simulationRun")
+    created: str
+    updated: str
+    name: str
+    summary: str
+    model_format: str = ""
+    image_url: str | None = None
+
+
+class ProjectStubPage(BaseModel):
+    """A page of results plus the total match count (for the pager)."""
+
+    items: list[ProjectStub]
+    total: int

--- a/backend/biosim_server/projects/router.py
+++ b/backend/biosim_server/projects/router.py
@@ -1,0 +1,85 @@
+"""Routes for the BioSim DB project search API.
+
+Two decoupled GET endpoints replace the legacy ``/projects/summary_filtered``
+so paging through slim results is independent of the heavier facet computation
+(see ``docs/project-search-api-plan.md``).
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import ValidationError
+
+from biosim_server.dependencies import get_project_database_service
+from biosim_server.projects.models import (
+    ProjectQueryStat,
+    ProjectSearchFilter,
+    ProjectStubPage,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/projects", tags=["Projects"])
+
+
+def _parse_filters(filters_json: str) -> list[ProjectSearchFilter]:
+    """Parse the ``filters`` query param (JSON array of ProjectSearchFilter).
+
+    An empty/blank value means "no filters". Malformed JSON or a shape mismatch
+    is a client error (400), not a 500."""
+    if not filters_json or not filters_json.strip():
+        return []
+    try:
+        raw = json.loads(filters_json)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"filters is not valid JSON: {e}")
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=400, detail="filters must be a JSON array")
+    try:
+        return [ProjectSearchFilter.model_validate(item) for item in raw]
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=f"invalid filter item: {e}")
+
+
+@router.get(
+    "",
+    response_model=ProjectStubPage,
+    operation_id="list-projects",
+    summary="Search published projects (paginated slim results)",
+)
+async def list_projects(
+    page: int = Query(default=1, ge=1, description="1-indexed page number."),
+    perPage: int = Query(default=20, ge=1, le=200, description="Results per page."),
+    filters: str = Query(default="", description="JSON array of {target, allowable_values}."),
+    searchTerm: str = Query(default="", description="Free-text search across title/abstract/description."),
+) -> ProjectStubPage:
+    projects_db = get_project_database_service()
+    if projects_db is None:
+        raise HTTPException(status_code=503, detail="Project database service not available")
+
+    parsed_filters = _parse_filters(filters)
+    stubs, total = await projects_db.query_project_stubs(
+        page=page, per_page=perPage, filters=parsed_filters, search_term=searchTerm.strip()
+    )
+    return ProjectStubPage(items=stubs, total=total)
+
+
+@router.get(
+    "/stats",
+    response_model=list[ProjectQueryStat],
+    operation_id="list-project-stats",
+    summary="Facet counts (tags & categories) for a project search",
+)
+async def list_project_stats(
+    filters: str = Query(default="", description="JSON array of {target, allowable_values}."),
+    searchTerm: str = Query(default="", description="Free-text search across title/abstract/description."),
+) -> list[ProjectQueryStat]:
+    projects_db = get_project_database_service()
+    if projects_db is None:
+        raise HTTPException(status_code=503, detail="Project database service not available")
+
+    parsed_filters = _parse_filters(filters)
+    return await projects_db.query_project_stats(
+        filters=parsed_filters, search_term=searchTerm.strip()
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,7 +13,8 @@ from tests.fixtures.database_fixtures import (  # noqa: F401
     mongo_test_collection,
     database_service_mongo,
     omex_database_service_mongo,
-    simulation_run_database_service_mongo
+    simulation_run_database_service_mongo,
+    project_database_service_mongo
 )
 from tests.fixtures.gcs_fixtures import (  # noqa: F401
     file_service_gcs,

--- a/backend/tests/fixtures/database_fixtures.py
+++ b/backend/tests/fixtures/database_fixtures.py
@@ -6,10 +6,13 @@ from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase, AsyncI
 from testcontainers.mongodb import MongoDbContainer  # type: ignore
 
 from biosim_server.biosim_runs import DatabaseServiceMongo
+from biosim_server.config import get_settings
 from biosim_server.dependencies import set_database_service, get_database_service, set_omex_database_service, \
-    get_omex_database_service, set_simulation_run_database_service, get_simulation_run_database_service
+    get_omex_database_service, set_simulation_run_database_service, get_simulation_run_database_service, \
+    set_project_database_service, get_project_database_service
 from biosim_server.biosim_omex import OmexDatabaseServiceMongo
 from biosim_server.simulations import SimulationRunDatabaseServiceMongo
+from biosim_server.projects import ProjectDatabaseServiceMongo
 
 MONGODB_DATABASE_NAME = "mydatabase"
 MONGODB_COLLECTION_NAME = "mycollection"
@@ -79,3 +82,32 @@ async def simulation_run_database_service_mongo(
     await runs_db_service.delete_all_simulation_runs()
     set_simulation_run_database_service(old_runs_db_service)
     # await db_service.close()  the underlying client will already be closed
+
+
+@pytest_asyncio.fixture(scope="function")
+async def project_database_service_mongo(
+    mongo_test_client: AsyncIOMotorClient,
+) -> AsyncGenerator[
+    tuple[ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection],
+    None,
+]:
+    """Project service plus the (Projects, Metadata, Specifications) collections.
+
+    The service assembles from ``Projects`` joined to ``Metadata`` (display fields
+    + facets) and ``Specifications`` (model_format) on ``simulationRun``; the test
+    inserts fixture docs into those same collections, then drops them."""
+    settings = get_settings()
+    database = mongo_test_client.get_database(settings.mongodb_database)
+    projects_col = database.get_collection(settings.mongodb_collection_projects)
+    metadata_col = database.get_collection(settings.mongodb_collection_metadata)
+    specifications_col = database.get_collection(settings.mongodb_collection_specifications)
+    projects_db_service = ProjectDatabaseServiceMongo(db_client=mongo_test_client)
+    old_projects_db_service = get_project_database_service()
+    set_project_database_service(projects_db_service)
+
+    yield projects_db_service, projects_col, metadata_col, specifications_col
+
+    await projects_col.delete_many({})
+    await metadata_col.delete_many({})
+    await specifications_col.delete_many({})
+    set_project_database_service(old_projects_db_service)

--- a/backend/tests/projects/test_project_search.py
+++ b/backend/tests/projects/test_project_search.py
@@ -1,0 +1,328 @@
+"""Tests for the BioSim DB project search API: GET /projects and /projects/stats.
+
+Covers three layers:
+  * pure query/shape helpers (build_match_stage, _stub_from_agg, _label_values) — no DB,
+  * the Mongo-backed ProjectDatabaseService — testcontainers Mongo, exercising the
+    Projects -> Metadata join, pagination correctness, search, and facet stats,
+  * the FastAPI endpoints — TestClient with a mocked project DB service.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from biosim_server.api.main import app
+from biosim_server.projects import (
+    ProjectDatabaseServiceMongo,
+    ProjectSearchFilter,
+    ProjectStub,
+    build_match_stage,
+)
+from biosim_server.projects.database import (
+    _META,
+    _format_from_language_urn,
+    _image_url,
+    _label_values,
+    _stub_from_agg,
+)
+
+_API = "https://api.biosimulations.org"
+
+
+def _project_doc(project_id: str, *, run: str | None = None, updated: datetime | None = None) -> dict[str, Any]:
+    when = updated or datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return {
+        "id": project_id,
+        "simulationRun": run or f"run-{project_id}",
+        "owner": None,
+        "created": when,
+        "updated": when,
+    }
+
+
+def _metadata_doc(
+    run: str,
+    *,
+    title: str = "A model",
+    abstract: str | None = "an abstract",
+    description: str | None = None,
+    taxa: list[str] | None = None,
+    keywords: list[str] | None = None,
+    thumbnails: list[str] | None = None,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {"title": title}
+    if abstract is not None:
+        item["abstract"] = abstract
+    if description is not None:
+        item["description"] = description
+    if taxa is not None:
+        item["taxa"] = [{"uri": None, "label": t} for t in taxa]
+    if keywords is not None:
+        item["keywords"] = keywords
+    if thumbnails is not None:
+        item["thumbnails"] = thumbnails
+    return {"simulationRun": run, "metadata": [item]}
+
+
+def _spec_doc(run: str, *, languages: list[str]) -> dict[str, Any]:
+    return {"simulationRun": run, "models": [{"language": lg} for lg in languages]}
+
+
+async def _seed(projects_col: AsyncIOMotorCollection, metadata_col: AsyncIOMotorCollection,
+                pairs: list[tuple[dict[str, Any], dict[str, Any] | None]],
+                specifications_col: AsyncIOMotorCollection | None = None,
+                specs: list[dict[str, Any]] | None = None) -> None:
+    for project, metadata in pairs:
+        await projects_col.insert_one(project)
+        if metadata is not None:
+            await metadata_col.insert_one(metadata)
+    if specifications_col is not None and specs:
+        for spec in specs:
+            await specifications_col.insert_one(spec)
+
+
+# --------------------------- pure helpers ---------------------------
+
+def test_match_stage_empty_is_none() -> None:
+    assert build_match_stage([], "") is None
+
+
+def test_match_stage_search_only() -> None:
+    stage = build_match_stage([], "yeast")
+    assert stage is not None and "$or" in stage
+    assert any(f"{_META}.title" in clause for clause in stage["$or"])
+
+
+def test_match_stage_filter_and_search_are_anded() -> None:
+    stage = build_match_stage([ProjectSearchFilter(target="taxa", allowable_values=["X"])], "cell cycle")
+    assert stage is not None and "$and" in stage and len(stage["$and"]) == 2
+
+
+def test_match_stage_unknown_target_ignored() -> None:
+    assert build_match_stage([ProjectSearchFilter(target="bogus", allowable_values=["v"])], "") is None
+
+
+def test_label_values_handles_strings_and_objects() -> None:
+    assert _label_values(["a", "b"]) == ["a", "b"]
+    assert _label_values([{"label": "x"}, {"label": "y"}]) == ["x", "y"]
+    assert _label_values([{"label": "x"}, "y", {"nolabel": 1}]) == ["x", "y"]
+    assert _label_values(None) == []
+
+
+def test_stub_from_agg_maps_joined_metadata() -> None:
+    doc = {"id": "proj-1", "simulationRun": "run-1", "created": "2024-01-01T00:00:00Z",
+           "updated": "2024-01-01T00:00:00Z",
+           _META: {"title": "T", "abstract": "A", "thumbnails": ["Figure2.jpg"]},
+           "_models": [{"language": "urn:sedml:language:sbml"}]}
+    stub = _stub_from_agg(doc, _API)
+    assert isinstance(stub, ProjectStub)
+    assert (stub.id, stub.simulation_run, stub.name, stub.summary) == ("proj-1", "run-1", "T", "A")
+    assert stub.model_format == "SBML"
+    assert stub.image_url == f"{_API}/files/run-1/Figure2.jpg/download/?thumbnail=browse"
+
+
+def test_stub_from_agg_falls_back_when_metadata_missing() -> None:
+    stub = _stub_from_agg({"id": "proj-2", "simulationRun": "run-2", _META: {}}, _API)
+    assert stub.name == "proj-2"  # no title -> id
+    assert stub.summary == ""
+    assert stub.model_format == ""
+    assert stub.image_url is None
+
+
+def test_format_from_language_urn() -> None:
+    assert _format_from_language_urn("urn:sedml:language:sbml") == "SBML"
+    assert _format_from_language_urn("urn:sedml:language:sbml.level-2.version-3") == "SBML"
+    assert _format_from_language_urn("urn:sedml:language:cellml.1_0") == "CELLML"
+    assert _format_from_language_urn("urn:sedml:language:vcml") == "VCML"
+    assert _format_from_language_urn(None) == ""
+
+
+def test_image_url_variants() -> None:
+    # absolute url passes through
+    assert _image_url("run-1", ["https://cdn/x.png"], _API) == "https://cdn/x.png"
+    # bare filename -> download endpoint, url-encoded
+    assert _image_url("run-1", ["a b.jpg"], _API) == f"{_API}/files/run-1/a%20b.jpg/download/?thumbnail=browse"
+    # nothing to resolve
+    assert _image_url("run-1", [], _API) is None
+    assert _image_url("run-1", None, _API) is None
+
+
+# --------------------------- Mongo-backed service (Projects x Metadata) ---------------------------
+
+@pytest.mark.asyncio
+async def test_db_join_and_pagination(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    """Assemble from Projects joined to Metadata; assert correct totals and
+    non-overlapping, correctly-sized pages (the legacy past-page-1 bug)."""
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    pairs: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+    for i in range(25):
+        run = f"run-{i:02d}"
+        pairs.append((_project_doc(f"p{i:02d}", run=run), _metadata_doc(run, title=f"Model {i:02d}")))
+    await _seed(projects_col, metadata_col, pairs)
+
+    page1, total = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="")
+    assert total == 25 and len(page1) == 10
+    # the join populated the display name from Metadata
+    assert all(s.name.startswith("Model ") for s in page1)
+
+    page2, _ = await svc.query_project_stubs(page=2, per_page=10, filters=[], search_term="")
+    page3, _ = await svc.query_project_stubs(page=3, per_page=10, filters=[], search_term="")
+    assert len(page2) == 10 and len(page3) == 5  # remainder only
+
+    ids = {s.id for s in page1} | {s.id for s in page2} | {s.id for s in page3}
+    assert len(ids) == 25  # no overlap across pages
+
+
+@pytest.mark.asyncio
+async def test_db_project_without_metadata_still_listed(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    """A project whose run has no Metadata doc must still appear (name -> id)."""
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    await _seed(projects_col, metadata_col, [(_project_doc("lonely", run="run-x"), None)])
+    stubs, total = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="")
+    assert total == 1
+    assert stubs[0].id == "lonely" and stubs[0].name == "lonely" and stubs[0].summary == ""
+
+
+@pytest.mark.asyncio
+async def test_db_search_matches_metadata(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    await _seed(projects_col, metadata_col, [
+        (_project_doc("a", run="ra"), _metadata_doc("ra", title="Yeast cell cycle", abstract="budding yeast")),
+        (_project_doc("b", run="rb"), _metadata_doc("rb", title="Cardiac model", abstract="heart")),
+    ])
+    stubs, total = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="yeast")
+    assert total == 1 and [s.id for s in stubs] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_db_filter_by_taxa(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    await _seed(projects_col, metadata_col, [
+        (_project_doc("a", run="ra"), _metadata_doc("ra", taxa=["Human"])),
+        (_project_doc("b", run="rb"), _metadata_doc("rb", taxa=["Yeast"])),
+    ])
+    stubs, total = await svc.query_project_stubs(
+        page=1, per_page=10, filters=[ProjectSearchFilter(target="taxa", allowable_values=["Human"])], search_term="")
+    assert total == 1 and [s.id for s in stubs] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_db_enriches_model_format_and_image_url(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    """Page items pick up model_format from Specifications and image_url from the
+    metadata thumbnail; a run without a Specifications doc degrades to empty."""
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    await _seed(
+        projects_col, metadata_col,
+        [
+            (_project_doc("a", run="ra"), _metadata_doc("ra", thumbnails=["Figure2.jpg"])),
+            (_project_doc("b", run="rb"), _metadata_doc("rb", thumbnails=None)),
+        ],
+        specifications_col=specifications_col,
+        specs=[_spec_doc("ra", languages=["urn:sedml:language:sbml.level-2.version-3"])],
+    )
+    stubs, _ = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="")
+    by_id = {s.id: s for s in stubs}
+    assert by_id["a"].model_format == "SBML"
+    assert by_id["a"].image_url is not None and by_id["a"].image_url.endswith(
+        "/files/ra/Figure2.jpg/download/?thumbnail=browse"
+    )
+    # b has neither a spec nor a thumbnail -> both degrade cleanly
+    assert by_id["b"].model_format == ""
+    assert by_id["b"].image_url is None
+
+
+@pytest.mark.asyncio
+async def test_db_stats_counts_facets_over_join(
+    project_database_service_mongo: tuple[
+        ProjectDatabaseServiceMongo, AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ],
+) -> None:
+    svc, projects_col, metadata_col, specifications_col = project_database_service_mongo
+    await _seed(projects_col, metadata_col, [
+        (_project_doc("a", run="ra"), _metadata_doc("ra", taxa=["Human"], keywords=["cardiac"])),
+        (_project_doc("b", run="rb"), _metadata_doc("rb", taxa=["Human"], keywords=["neural"])),
+        (_project_doc("c", run="rc"), _metadata_doc("rc", taxa=["Yeast"])),
+    ])
+    stats = await svc.query_project_stats(filters=[], search_term="")
+    by_target = {s.target: s for s in stats}
+    taxa_counts = {vf.value: vf.count for vf in by_target["taxa"].value_frequencies}
+    assert taxa_counts == {"Human": 2, "Yeast": 1}
+    assert by_target["taxa"].value_frequencies[0].value == "Human"  # descending by count
+
+
+# --------------------------- FastAPI endpoints ---------------------------
+
+@patch("biosim_server.projects.router.get_project_database_service")
+def test_endpoint_service_unavailable(mock_get_db: MagicMock) -> None:
+    mock_get_db.return_value = None
+    client = TestClient(app)
+    assert client.get("/projects").status_code == 503
+
+
+@patch("biosim_server.projects.router.get_project_database_service")
+def test_endpoint_bad_filters_json(mock_get_db: MagicMock) -> None:
+    mock_get_db.return_value = AsyncMock()
+    client = TestClient(app)
+    resp = client.get("/projects", params={"filters": "{not json"})
+    assert resp.status_code == 400
+
+
+@patch("biosim_server.projects.router.get_project_database_service")
+def test_endpoint_success_shape(mock_get_db: MagicMock) -> None:
+    db = AsyncMock()
+    db.query_project_stubs.return_value = (
+        [ProjectStub(id="a", simulation_run="run-a", created="2024-01-01T00:00:00Z",
+                     updated="2024-01-01T00:00:00Z", name="Model A", summary="s")],
+        1,
+    )
+    mock_get_db.return_value = db
+    client = TestClient(app)
+    resp = client.get("/projects", params={"page": 1, "perPage": 20})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1 and len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["id"] == "a"
+    assert item["simulationRun"] == "run-a"  # camelCase alias
+    assert item["name"] == "Model A"
+
+
+@patch("biosim_server.projects.router.get_project_database_service")
+def test_endpoint_stats_shape(mock_get_db: MagicMock) -> None:
+    from biosim_server.projects import ProjectQueryStat, ValueFrequency
+
+    db = AsyncMock()
+    db.query_project_stats.return_value = [
+        ProjectQueryStat(target="taxa", value_frequencies=[ValueFrequency(value="Human", count=2)])
+    ]
+    mock_get_db.return_value = db
+    client = TestClient(app)
+    resp = client.get("/projects/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["target"] == "taxa"
+    assert body[0]["valueFrequencies"][0] == {"value": "Human", "count": 2}

--- a/docs/project-search-api-plan.md
+++ b/docs/project-search-api-plan.md
@@ -1,0 +1,173 @@
+# Project Search API — two-week plan (→ CRBM demo 2026-07-30)
+
+Milestone: demo the **project page + detail pages** at the CRBM group meeting on
+**Wed 2026-07-30**. This plan covers the backend **project search API** (Jim);
+Harrison owns the detail pages against the contract below.
+
+Source of the ask: `docs/biosim-db-api-wishlist-and-fixes.md`.
+
+---
+
+## Where we are today
+
+- The frontend `frontend/app/pages/biosim-db.vue` calls the **legacy external API**
+  (`LEGACY_API_URL` → `api.biosimulations.org`) at `GET /projects/summary_filtered`,
+  then makes a **per-project** `GET /files/{simulationRunId}` call to find a `.png`
+  thumbnail. So one page render = 1 + N HTTP calls to a service we don't control.
+- The platform backend has **no** projects module yet. It does have the pieces we
+  need: `motor` async Mongo (`dependencies.py`), a `simulations/` module to mirror
+  (router / models / database), and config for Mongo + `biosimulations_api_base_url`.
+
+### How the legacy endpoint actually works (reference: `~/workspace/biosimulations`)
+`apps/api/src/projects/` —
+- `Projects` collection is thin: `{ id, simulationRun, owner, created, updated }`
+  (`project.model.ts`, collection `'Projects'`).
+- The rich summary (title, abstract, taxa, simulators, model format, reports,
+  keywords, thumbnail) is assembled by **joining each project to its SimulationRun
+  + metadata** (`_getProjectSummaries` → `getProjectSummary`), cached in memory.
+- Search is **in-memory elasticlunr** over that cached set (`projects.search.ts`),
+  not a Mongo query. Facet counts (`queryStats`) are computed in JS over the whole
+  set (`projects.filter.ts` → `gatherFilterValueStatistics`).
+- **Pagination bug root cause:** `getProjectSummariesWithoutSearch` loads a large
+  fixed slice (`maxNumRecordsToTextSearch`, page 0), sorts, then re-slices by
+  `pageIndex*pageSize`. Total-count and slice semantics differ between the
+  no-filter / filter / search branches, and the frontend sends a **1-indexed**
+  `pageIndex` where the API assumes **0-indexed** — past page 1 the window and the
+  reported total disagree, so "too many results" leak through.
+
+---
+
+## Day 1 outcome (2026-07-16) — data source decided: GO on direct Mongo
+
+Probed the live cluster from inside a running `api` pod (no credential exposure).
+**The platform's existing `MONGODB_URI` already reaches the data.** In
+`biosimulations-prod`:
+- `Projects` — 1392 docs, thin schema `{id, simulationRun, owner, created, updated}`.
+- `projectSummary` — **527 docs, but a DEAD ORPHAN.** Strict subset of `Projects`;
+  every `updated` falls in a frozen window **2022-02-05 .. 2022-06-10**. The 865
+  projects it lacks were all created 2023+. No current code writes it — the
+  biosimulations API service injects only `ProjectModel` (`Projects`) and builds
+  summaries from an **in-memory** cache; the platform and sibling tools never
+  reference it. It was populated by a materialization job that stopped ~June 2022
+  and was abandoned when the service moved to in-memory caching. **Do not depend
+  on it, and do not backfill it.**
+- `Metadata` — **272,849 docs, per-run, keyed by `simulationRun`**, same nested
+  `metadata[0]` shape (title/abstract/thumbnails/taxa/keywords/…). **200/200**
+  sampled projects that `projectSummary` misses DO have a `Metadata` doc. This is
+  the live, complete source: join `Projects` → `Metadata` on `simulationRun`.
+- Also present: `Metadata`, `Specifications`, `Files`, `Simulation Runs` (note the
+  space), `BiosimSimulationRuns`.
+
+Consequences:
+- **No new sealed secret needed for deployed read access** — same cluster/DB the
+  platform already uses. (The `../deployment` / `../secrets` creds matter for the
+  *local-dev* story instead — see the secrets-refactor follow-up.)
+- **Coverage gap to resolve:** `projectSummary` covers 527 of 1392 projects (likely
+  published-only or a warm cache). Confirm the intended denominator; decide whether
+  to compute-on-miss (legacy live join) or treat `projectSummary` as authoritative
+  for the demo.
+- `model_format` and `image_url` are **not** in the metadata — now joined in:
+  `model_format` from `Specifications.models[].language` (SED-ML URN → acronym)
+  via a page-scoped `$lookup`; `image_url` from `metadata.thumbnails[0]` built as
+  `{api}/files/{runId}/{file}/download/?thumbnail=browse` (verified 200 live). Both
+  degrade cleanly when absent.
+
+**Scaffold landed** (`backend/biosim_server/projects/`): `models.py`,
+`database.py` (async `ProjectDatabaseService` ABC + Mongo impl reading
+`projectSummary`), `router.py` (`GET /projects`, `GET /projects/stats`), wired
+into `config.py`, `dependencies.py`, `api/main.py`. 15 tests (pure + endpoint +
+testcontainers pagination) green; ruff + mypy clean. Pagination is 1-indexed with
+a real `count_documents` — the legacy bug is fixed by construction.
+
+## The one decision that gated the plan: data source
+
+**Recommendation — read the hosted Mongo directly (read-only), don't proxy the
+legacy HTTP API.** Rationale: the wishlist wants a *slim, fast, decoupled*
+endpoint; proxying inherits the legacy latency and the N+1. We already speak
+`motor`. Direct Mongo lets us do real `skip/limit/count` pagination and (later)
+`$facet` aggregation for the stats.
+
+Open questions to resolve **Day 1** (these are the schedule risk):
+1. Is the hosted `Projects` + `SimulationRuns` Mongo reachable from our backend
+   (network + read-only credentials)? If not, fall back to **proxy-and-reshape**
+   the legacy endpoint for the demo, and defer direct DB to post-demo.
+2. Do we replicate the summary-assembly join, or is there a materialized summary we
+   can read? (Legacy assembles it live from SimulationRun metadata.)
+3. Thumbnail: can we resolve `image_url` from SimulationRun metadata server-side so
+   the frontend's per-project `/files` call goes away? (Design goal: yes.)
+
+---
+
+## Target contract (from the wishlist)
+
+Split the one endpoint into two, so the heavy facet computation is decoupled from
+paging through results.
+
+**`GET /projects` — slim, paginated results**
+- query: `page`, `perPage`, `filters` (JSON `ValueFrequency[]`), `searchTerm`
+- returns: `{ items: ProjectStub[], total: number }`
+```ts
+interface ProjectStub {
+  id: number; simulationRun: string; created: string; updated: string;
+  name: string; summary: string; model_format: string; image_url?: string;
+}
+```
+
+**`GET /projects/stats` (facets) — tags & categories**
+- query: same shape (`page, perPage, filters, searchTerm`) so counts can reflect
+  the active query
+- returns: `ProjectQueryStat[]` = `{ target, valueFrequencies: {value,count}[] }`
+
+Keep field names aligned with `frontend/app/models/projects.ts` so Harrison's types
+don't drift.
+
+---
+
+## Two-week breakdown
+
+### Week 1 (07-16 → 07-22): make it real
+- **D1 — de-risk the data source.** Answer the 3 questions above; confirm Mongo
+  reachability + creds, or commit to the proxy fallback. *This is the go/no-go for
+  direct-DB.* Everything below is written to work either way behind a service iface.
+- **D1–2 — scaffold the module.** `backend/biosim_server/projects/` mirroring
+  `simulations/`: `models.py` (ProjectStub, ProjectQueryStat, ValueFrequency),
+  `database.py` (ProjectDatabaseService iface + Mongo impl), `router.py`, wire into
+  `api/main.py` + `dependencies.py`. Add `mongodb_collection_projects` to config.
+- **D2–3 — `GET /projects` happy path** with **correct** server-side pagination
+  (real `count` + `skip/limit`, 0-indexed, documented). Ship the pagination fix
+  by construction. Unit tests for page boundaries (the legacy bug).
+- **D3–4 — summary assembly + `image_url`.** Join to SimulationRun metadata; resolve
+  thumbnail server-side; kill the frontend N+1.
+- **D5 — `GET /projects/stats`** facet counts (start in app code mirroring
+  `gatherFilterValueStatistics`; optimize to `$facet` later). Filters applied.
+
+### Week 2 (07-23 → 07-29): correctness, search, integration
+- **D6 — `searchTerm`.** Simplest correct thing first: Mongo text/regex over
+  title+abstract+model language. (elasticlunr parity is a post-demo nice-to-have.)
+- **D6–7 — filters × search interaction**, and make `stats` reflect the active
+  query. Table-driven tests over filter/search/paging combinations.
+- **D7–8 — frontend integration with Harrison.** Point `biosim-db.vue` at the new
+  endpoints behind a flag; drop the per-project `/files` call. Verify the detail
+  pages get what they need. **Freeze the contract here.**
+- **D8–9 — perf + caching.** Whatever keeps the demo snappy: cache facet stats,
+  index the queried fields. Load-check against realistic project counts.
+- **D9 — buffer / polish / deploy** a backend Harrison can point at. Dry-run the
+  demo path end-to-end.
+
+Demo **07-30**.
+
+---
+
+## Risks
+- **Mongo access (highest).** If creds/networking slip, fall back to proxy-reshape
+  for the demo; direct-DB becomes post-demo. Decide D1, don't let it float.
+- **Summary-assembly cost.** The live join is why legacy is slow. If assembling on
+  our side is too slow, cache aggressively for the demo and optimize after.
+- **Contract churn vs Harrison.** Freeze names by D7–8; the wishlist `ProjectStub`
+  is the anchor. Every day of drift is a day off his detail-page work.
+- **biosim-client impact.** New/changed endpoints may affect the external client —
+  check before opening the PR.
+
+## Explicitly out of scope for the demo
+elasticlunr-quality relevance ranking, write/publish endpoints, auth on the new
+endpoints (read-only public data), full `$facet` optimization.


### PR DESCRIPTION
## What

Replaces the legacy `/projects/summary_filtered` with two decoupled GET endpoints for the BioSim DB page:

- **`GET /projects`** — slim, paginated results (`ProjectStub[]` + `total`)
- **`GET /projects/stats`** — facet counts (`ProjectQueryStat[]`) for tags/categories

Splitting them lets the frontend page through results without re-running the heavier facet computation each time. Field names match `frontend/app/models/projects.ts` so the frontend types don't drift.

## Data source

Assembled **live** from the authoritative `Projects` collection (1392, all published projects) joined to per-run `Metadata` (display fields + facets) and `Specifications` (`model_format`), so results are complete and always current.

The pre-2022 `projectSummary` collection is **not** used — it's a dead orphan (strict subset of 527, frozen 2022-02..2022-06, missing all 2023+ projects, written by nothing). biosimulations' own `/summary` endpoint doesn't read it either; it assembles live and caches in Redis. See `docs/project-search-api-plan.md` for the full trace.

- **`model_format`** ← `Specifications.models[].language` (SED-ML URN → acronym, e.g. `urn:sedml:language:sbml.level-2.version-3` → `SBML`), via a `$lookup` scoped **inside the `$facet` page sub-pipeline** so it resolves only the ~per-page rows, not every match.
- **`image_url`** ← `metadata.thumbnails[0]`, built as `{biosimulations_api_base_url}/files/{runId}/{file}/download/?thumbnail=browse` (verified 200). No extra Files-collection join.
- Both degrade cleanly (`""` / `null`) when absent.

Facet stats are cached in a **platform-owned in-process TTL cache** so paging stays cheap. DB access lives behind the `ProjectDatabaseService` ABC (async motor), mirroring the `simulations/` module.

## Notable fix

Pagination is **1-indexed with a real count via `$facet`**, fixing the legacy `summary_filtered` bug (too many results past page 1) by construction.

## Verification

- **19 tests** — pure helpers (URN→format, thumbnail-URL builder, query construction) + testcontainers Mongo (join, pagination windows, search, taxa filter, `model_format`/`image_url` enrichment, facet stats) + endpoint tests. `ruff` + `mypy --strict` clean.
- **Live-validated** against production: the full enriched pipeline returns all 1392 projects with real formats (SBML, SMOLDYN, CELLML, XPP, RBA, LEMS, BNGL) and thumbnail URLs that HEAD-check 200.

## Follow-ups (not in this PR)

- `Specifications`/`Files` join is done; remaining plan items are filter×search polish and wiring the frontend `biosim-db.vue` to these endpoints (dropping its per-project `/files` call).
- Local dev needs the hosted Mongo URI portably (ties into the secrets refactor) — read access already works from the deployed cluster via the platform's own secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm