### PR TITLE
Refactor secret management to per-overlay secrets.sh + secrets.dat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,7 @@ config.env
 *.sbatch
 
 backend/local_cache/
+
+# Per-overlay plaintext secrets (source for sealed secrets). Only the
+# secrets.dat.template is committed; the filled-in secrets.dat never is.
+kustomize/overlays/**/secrets.dat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,28 @@ All three workflows run on every PR (path filters were removed — cross-service
 
 `lefthook.yml` runs the lint/typecheck/ruff/mypy checks locally on pre-commit and pre-push so most failures are caught before CI. Install with `lefthook install` after `brew install lefthook`.
 
+## Secrets (sealed secrets)
+
+Each deploy overlay (`kustomize/overlays/biosim-{gke,rke,local}/`) owns its
+cluster secrets via three files, modeled on `../sms-api`:
+
+- **`secrets.dat.template`** (committed) — documents the required keys
+  (`MONGODB_URI`, `GCS_CREDENTIALS_FILE`, `GH_USER_NAME/EMAIL/PAT`, optional
+  kubeseal targeting).
+- **`secrets.dat`** (gitignored — `kustomize/overlays/**/secrets.dat`) — your
+  filled-in plaintext values. Never committed.
+- **`secrets.sh`** (committed) — sources `secrets.dat` and regenerates the
+  overlay's `secret-shared.yaml` + `secret-ghcr.yaml` (the committed, encrypted
+  `SealedSecret`s) via `kustomize/scripts/sealed_secret_{shared,ghcr}.sh`.
+
+Workflow: `cp secrets.dat.template secrets.dat`, fill it in, `./secrets.sh`,
+review + commit the regenerated `secret-*.yaml`. Plaintext lives only in
+`secrets.dat` — this replaces the old flow of stashing secrets in `~/.ssh`.
+Get the hosted `MONGODB_URI` / GCS creds from the `../deployment` / `../secrets`
+repos. For local backend dev against real project data, point
+`backend/.env`'s `MONGODB_URI` at the hosted read-only URI (see
+`backend/.env.example`).
+
 ## Ingress / hosts (prod)
 
 Subdomain split: `biosim.biosimulations.org` → frontend; `api.biosim.biosimulations.org` → backend. SSR traffic inside the cluster uses `API_URL_INTERNAL=http://api:8000` to skip the public ingress.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,13 @@ STORAGE_LOCAL_CACHE_DIR=./local_cache
 # Infra (matches compose.yaml).
 TEMPORAL_SERVICE_URL=localhost:7233
 MONGODB_URI=mongodb://localhost:27017
+# The local Mongo above is empty. To work on the project search API
+# (GET /projects) locally you need real project data, which lives in the hosted
+# biosimulations-prod Mongo. Point MONGODB_URI at the hosted read-only URI for
+# that work. Get the URI from your overlay's secrets.dat (kustomize/overlays/*/,
+# key MONGODB_URI) or the ../deployment / ../secrets repos — never commit it.
+# MONGODB_URI=mongodb+srv://READONLY_USER:PASSWORD@HOST/biosimulations-prod?retryWrites=true&w=majority
+# MONGODB_DATABASE=biosimulations-prod
 
 # External APIs. Defaults point at production biosimulations.org — the local
 # backend calls these for real simulation runs. Override only to target a

--- a/kustomize/overlays/biosim-gke/secrets.dat.template
+++ b/kustomize/overlays/biosim-gke/secrets.dat.template
@@ -1,0 +1,25 @@
+# Template for secrets.dat (overlay: biosim-gke)
+# Copy this file to secrets.dat and fill in real values, then run ./secrets.sh
+# DO NOT commit secrets.dat — it is gitignored (kustomize/overlays/**/secrets.dat).
+
+# --- shared-secrets: backend Mongo + GCS storage ---
+# Hosted MongoDB connection string (read/write app user). For the biosim-*
+# clusters this points at the biosimulations-prod Atlas cluster. Get it from the
+# ../deployment / ../secrets repos (or a cluster admin).
+MONGODB_URI=mongodb+srv://USER:PASSWORD@HOST/biosimulations-prod?retryWrites=true&w=majority
+# Absolute path to the GCS service-account JSON used for file storage.
+GCS_CREDENTIALS_FILE=/absolute/path/to/gcs-credentials.json
+
+# --- ghcr-secret: pulling images from ghcr.io/biosimulations/* ---
+GH_USER_NAME=your_github_username
+GH_USER_EMAIL=your_email@example.com
+GH_PAT=ghp_YOURPERSONALACCESSTOKEN
+
+# --- kubeseal targeting (optional) ---
+# GKE seals offline against a fetched cert. Fetch once, then set the path:
+#   kubeseal --controller-name=sealed-secrets-controller \
+#            --controller-namespace=sealed-secrets --fetch-cert > gke-cert.pem
+SEALED_SECRETS_CERT=/absolute/path/to/gke-cert.pem
+# If sealing against an in-cluster controller instead, set these and unset CERT:
+# SEALED_SECRETS_CONTROLLER_NAME=sealed-secrets-controller
+# SEALED_SECRETS_CONTROLLER_NAMESPACE=sealed-secrets

--- a/kustomize/overlays/biosim-gke/secrets.sh
+++ b/kustomize/overlays/biosim-gke/secrets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Regenerate this overlay's committed sealed secrets from local plaintext values.
+#
+#   1. cp secrets.dat.template secrets.dat   # secrets.dat is gitignored
+#   2. edit secrets.dat with your real values
+#   3. ./secrets.sh                          # rewrites secret-shared.yaml + secret-ghcr.yaml
+#   4. review + commit the regenerated secret-*.yaml
+#
+# Plaintext lives only in secrets.dat (never committed); the sealed output is
+# safe to commit. This replaces the old flow of stashing secrets in ~/.ssh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
+
+NAMESPACE=biosim-gke
+SCRIPTS_DIR="${REPO_ROOT}/kustomize/scripts"
+SECRETS_DIR="${SCRIPT_DIR}"
+
+SECRETS_DATA_FILE="${SECRETS_DIR}/secrets.dat"
+if [ ! -f "${SECRETS_DATA_FILE}" ]; then
+    echo "ERROR: secrets data file not found: ${SECRETS_DATA_FILE}"
+    echo "Create it from the template:"
+    echo "  cp ${SECRETS_DIR}/secrets.dat.template ${SECRETS_DIR}/secrets.dat"
+    echo "  # then edit secrets.dat with your real values"
+    exit 1
+fi
+
+echo "Loading secrets from: ${SECRETS_DATA_FILE}"
+# shellcheck disable=SC1090
+source "${SECRETS_DATA_FILE}"
+
+# Assemble optional kubeseal targeting from secrets.dat. GKE typically seals
+# offline against a fetched cert (SEALED_SECRETS_CERT); on-cluster controllers
+# (RKE/local) are found by name.
+KUBESEAL_ARGS=()
+[ -n "${SEALED_SECRETS_CERT:-}" ] && KUBESEAL_ARGS+=(--cert "${SEALED_SECRETS_CERT}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ] && KUBESEAL_ARGS+=(--controller-name "${SEALED_SECRETS_CONTROLLER_NAME}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ] && KUBESEAL_ARGS+=(--controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}")
+
+echo ""
+echo "=== Generating sealed secrets for ${NAMESPACE} ==="
+
+echo "Generating shared-secrets (Mongo + GCS)..."
+"${SCRIPTS_DIR}/sealed_secret_shared.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${MONGODB_URI}" "${GCS_CREDENTIALS_FILE}" \
+    > "${SECRETS_DIR}/secret-shared.yaml"
+echo "✓ secret-shared.yaml"
+
+echo "Generating ghcr-secret (GHCR image pulls)..."
+"${SCRIPTS_DIR}/sealed_secret_ghcr.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${GH_USER_NAME}" "${GH_USER_EMAIL}" "${GH_PAT}" \
+    > "${SECRETS_DIR}/secret-ghcr.yaml"
+echo "✓ secret-ghcr.yaml"
+
+echo ""
+echo "=== Done. Review the regenerated secret-*.yaml, then commit them. ==="

--- a/kustomize/overlays/biosim-local/secrets.dat.template
+++ b/kustomize/overlays/biosim-local/secrets.dat.template
@@ -1,0 +1,25 @@
+# Template for secrets.dat (overlay: biosim-local)
+# Copy this file to secrets.dat and fill in real values, then run ./secrets.sh
+# DO NOT commit secrets.dat — it is gitignored (kustomize/overlays/**/secrets.dat).
+#
+# biosim-local deploys to a local cluster (e.g. minikube) with an in-cluster
+# Mongo, so these values are mostly local/placeholder rather than production.
+
+# --- shared-secrets: backend Mongo + GCS storage ---
+# In-cluster Mongo for the local deployment (no Atlas). To develop the project
+# search API against real data instead, point this (or backend/.env) at the
+# hosted read-only Mongo URI — see backend/.env.example.
+MONGODB_URI=mongodb://mongodb:27017/biosimulations
+# GCS SA JSON; local storage uses minio, so a placeholder file is fine.
+GCS_CREDENTIALS_FILE=/absolute/path/to/gcs-credentials.json
+
+# --- ghcr-secret: pulling images from ghcr.io/biosimulations/* ---
+GH_USER_NAME=your_github_username
+GH_USER_EMAIL=your_email@example.com
+GH_PAT=ghp_YOURPERSONALACCESSTOKEN
+
+# --- kubeseal targeting ---
+# Local sealed-secrets controller, found by name (default values shown).
+SEALED_SECRETS_CONTROLLER_NAME=sealed-secrets-controller
+SEALED_SECRETS_CONTROLLER_NAMESPACE=sealed-secrets
+# SEALED_SECRETS_CERT=/absolute/path/to/local-cert.pem

--- a/kustomize/overlays/biosim-local/secrets.sh
+++ b/kustomize/overlays/biosim-local/secrets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Regenerate this overlay's committed sealed secrets from local plaintext values.
+#
+#   1. cp secrets.dat.template secrets.dat   # secrets.dat is gitignored
+#   2. edit secrets.dat with your real values
+#   3. ./secrets.sh                          # rewrites secret-shared.yaml + secret-ghcr.yaml
+#   4. review + commit the regenerated secret-*.yaml
+#
+# Plaintext lives only in secrets.dat (never committed); the sealed output is
+# safe to commit. This replaces the old flow of stashing secrets in ~/.ssh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
+
+NAMESPACE=biosim-local
+SCRIPTS_DIR="${REPO_ROOT}/kustomize/scripts"
+SECRETS_DIR="${SCRIPT_DIR}"
+
+SECRETS_DATA_FILE="${SECRETS_DIR}/secrets.dat"
+if [ ! -f "${SECRETS_DATA_FILE}" ]; then
+    echo "ERROR: secrets data file not found: ${SECRETS_DATA_FILE}"
+    echo "Create it from the template:"
+    echo "  cp ${SECRETS_DIR}/secrets.dat.template ${SECRETS_DIR}/secrets.dat"
+    echo "  # then edit secrets.dat with your real values"
+    exit 1
+fi
+
+echo "Loading secrets from: ${SECRETS_DATA_FILE}"
+# shellcheck disable=SC1090
+source "${SECRETS_DATA_FILE}"
+
+# Assemble optional kubeseal targeting from secrets.dat. GKE typically seals
+# offline against a fetched cert (SEALED_SECRETS_CERT); on-cluster controllers
+# (RKE/local) are found by name.
+KUBESEAL_ARGS=()
+[ -n "${SEALED_SECRETS_CERT:-}" ] && KUBESEAL_ARGS+=(--cert "${SEALED_SECRETS_CERT}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ] && KUBESEAL_ARGS+=(--controller-name "${SEALED_SECRETS_CONTROLLER_NAME}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ] && KUBESEAL_ARGS+=(--controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}")
+
+echo ""
+echo "=== Generating sealed secrets for ${NAMESPACE} ==="
+
+echo "Generating shared-secrets (Mongo + GCS)..."
+"${SCRIPTS_DIR}/sealed_secret_shared.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${MONGODB_URI}" "${GCS_CREDENTIALS_FILE}" \
+    > "${SECRETS_DIR}/secret-shared.yaml"
+echo "✓ secret-shared.yaml"
+
+echo "Generating ghcr-secret (GHCR image pulls)..."
+"${SCRIPTS_DIR}/sealed_secret_ghcr.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${GH_USER_NAME}" "${GH_USER_EMAIL}" "${GH_PAT}" \
+    > "${SECRETS_DIR}/secret-ghcr.yaml"
+echo "✓ secret-ghcr.yaml"
+
+echo ""
+echo "=== Done. Review the regenerated secret-*.yaml, then commit them. ==="

--- a/kustomize/overlays/biosim-rke/secrets.dat.template
+++ b/kustomize/overlays/biosim-rke/secrets.dat.template
@@ -1,0 +1,24 @@
+# Template for secrets.dat (overlay: biosim-rke)
+# Copy this file to secrets.dat and fill in real values, then run ./secrets.sh
+# DO NOT commit secrets.dat — it is gitignored (kustomize/overlays/**/secrets.dat).
+
+# --- shared-secrets: backend Mongo + GCS storage ---
+# Hosted MongoDB connection string (read/write app user) for the RKE prod tier.
+# Get it from the ../deployment / ../secrets repos (or a cluster admin).
+MONGODB_URI=mongodb+srv://USER:PASSWORD@HOST/biosimulations?retryWrites=true&w=majority
+# Absolute path to the GCS service-account JSON used for file storage.
+GCS_CREDENTIALS_FILE=/absolute/path/to/gcs-credentials.json
+
+# --- ghcr-secret: pulling images from ghcr.io/biosimulations/* ---
+GH_USER_NAME=your_github_username
+GH_USER_EMAIL=your_email@example.com
+GH_PAT=ghp_YOURPERSONALACCESSTOKEN
+
+# --- kubeseal targeting ---
+# The on-cluster RKE controller is found by name (default values shown). Override
+# only if your controller is named/namespaced differently. Requires a kubectl
+# context pointed at the RKE cluster when running ./secrets.sh.
+SEALED_SECRETS_CONTROLLER_NAME=sealed-secrets-controller
+SEALED_SECRETS_CONTROLLER_NAMESPACE=sealed-secrets
+# Alternatively, seal offline against a fetched cert:
+# SEALED_SECRETS_CERT=/absolute/path/to/rke-cert.pem

--- a/kustomize/overlays/biosim-rke/secrets.sh
+++ b/kustomize/overlays/biosim-rke/secrets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Regenerate this overlay's committed sealed secrets from local plaintext values.
+#
+#   1. cp secrets.dat.template secrets.dat   # secrets.dat is gitignored
+#   2. edit secrets.dat with your real values
+#   3. ./secrets.sh                          # rewrites secret-shared.yaml + secret-ghcr.yaml
+#   4. review + commit the regenerated secret-*.yaml
+#
+# Plaintext lives only in secrets.dat (never committed); the sealed output is
+# safe to commit. This replaces the old flow of stashing secrets in ~/.ssh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
+
+NAMESPACE=biosim-rke
+SCRIPTS_DIR="${REPO_ROOT}/kustomize/scripts"
+SECRETS_DIR="${SCRIPT_DIR}"
+
+SECRETS_DATA_FILE="${SECRETS_DIR}/secrets.dat"
+if [ ! -f "${SECRETS_DATA_FILE}" ]; then
+    echo "ERROR: secrets data file not found: ${SECRETS_DATA_FILE}"
+    echo "Create it from the template:"
+    echo "  cp ${SECRETS_DIR}/secrets.dat.template ${SECRETS_DIR}/secrets.dat"
+    echo "  # then edit secrets.dat with your real values"
+    exit 1
+fi
+
+echo "Loading secrets from: ${SECRETS_DATA_FILE}"
+# shellcheck disable=SC1090
+source "${SECRETS_DATA_FILE}"
+
+# Assemble optional kubeseal targeting from secrets.dat. GKE typically seals
+# offline against a fetched cert (SEALED_SECRETS_CERT); on-cluster controllers
+# (RKE/local) are found by name.
+KUBESEAL_ARGS=()
+[ -n "${SEALED_SECRETS_CERT:-}" ] && KUBESEAL_ARGS+=(--cert "${SEALED_SECRETS_CERT}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ] && KUBESEAL_ARGS+=(--controller-name "${SEALED_SECRETS_CONTROLLER_NAME}")
+[ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ] && KUBESEAL_ARGS+=(--controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}")
+
+echo ""
+echo "=== Generating sealed secrets for ${NAMESPACE} ==="
+
+echo "Generating shared-secrets (Mongo + GCS)..."
+"${SCRIPTS_DIR}/sealed_secret_shared.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${MONGODB_URI}" "${GCS_CREDENTIALS_FILE}" \
+    > "${SECRETS_DIR}/secret-shared.yaml"
+echo "✓ secret-shared.yaml"
+
+echo "Generating ghcr-secret (GHCR image pulls)..."
+"${SCRIPTS_DIR}/sealed_secret_ghcr.sh" ${KUBESEAL_ARGS[@]+"${KUBESEAL_ARGS[@]}"} \
+    "${NAMESPACE}" "${GH_USER_NAME}" "${GH_USER_EMAIL}" "${GH_PAT}" \
+    > "${SECRETS_DIR}/secret-ghcr.yaml"
+echo "✓ secret-ghcr.yaml"
+
+echo ""
+echo "=== Done. Review the regenerated secret-*.yaml, then commit them. ==="

--- a/kustomize/scripts/sealed_secret_ghcr.sh
+++ b/kustomize/scripts/sealed_secret_ghcr.sh
@@ -13,12 +13,22 @@
 
 # Initialize variables
 CERT_ARG=""
+CONTROLLER_NAME="sealed-secrets-controller"
+CONTROLLER_NAMESPACE="sealed-secrets"
 
 # Parse optional arguments
 while [[ "$1" == --* ]]; do
   case "$1" in
     --cert)
       CERT_ARG="$2"
+      shift 2
+      ;;
+    --controller-name)
+      CONTROLLER_NAME="$2"
+      shift 2
+      ;;
+    --controller-namespace)
+      CONTROLLER_NAMESPACE="$2"
       shift 2
       ;;
     *)
@@ -42,10 +52,14 @@ USERNAME=$2
 EMAIL=$3
 PASSWORD=$4
 
-# Create the docker-registry secret and seal it
+# Create the docker-registry secret and seal it.
+# With --cert, kubeseal seals offline against that cert (needed for GKE);
+# otherwise it fetches the cert from the named controller in-cluster.
 kubectl create secret docker-registry ${SECRET_NAME} --dry-run=client \
       --docker-server="${SERVER}" \
       --docker-username="${USERNAME}" \
       --docker-email="${EMAIL}" \
       --docker-password="${PASSWORD}" \
-      --namespace="${NAMESPACE}" -o yaml | kubeseal --format yaml ${CERT_ARG:+--cert=$CERT_ARG}
+      --namespace="${NAMESPACE}" -o yaml \
+      | kubeseal --controller-name="${CONTROLLER_NAME}" --controller-namespace="${CONTROLLER_NAMESPACE}" \
+                 --format yaml ${CERT_ARG:+--cert=$CERT_ARG}

--- a/kustomize/scripts/sealed_secret_shared.sh
+++ b/kustomize/scripts/sealed_secret_shared.sh
@@ -16,12 +16,22 @@
 
 # Initialize variables
 CERT_ARG=""
+CONTROLLER_NAME="sealed-secrets-controller"
+CONTROLLER_NAMESPACE="sealed-secrets"
 
 # Parse optional arguments
 while [[ "$1" == --* ]]; do
   case "$1" in
     --cert)
       CERT_ARG="$2"
+      shift 2
+      ;;
+    --controller-name)
+      CONTROLLER_NAME="$2"
+      shift 2
+      ;;
+    --controller-namespace)
+      CONTROLLER_NAMESPACE="$2"
       shift 2
       ;;
     *)
@@ -43,8 +53,12 @@ NAMESPACE=$1
 MONGODB_URI=$2
 STORAGE_GCS_CREDENTIALS_FILE=$3
 
-# Create the generic secret and seal it
+# Create the generic secret and seal it.
+# When --cert is given, kubeseal seals offline against that cert (needed for GKE).
+# Otherwise it fetches the cert from the named controller in-cluster.
 kubectl create secret generic ${SECRET_NAME} --dry-run=client \
       --from-literal=mongodb-uri="${MONGODB_URI}" \
       --from-file=gcs_credentials.json="${STORAGE_GCS_CREDENTIALS_FILE}" \
-      --namespace="${NAMESPACE}" -o yaml | kubeseal --format yaml ${CERT_ARG:+--cert=$CERT_ARG}
+      --namespace="${NAMESPACE}" -o yaml \
+      | kubeseal --controller-name="${CONTROLLER_NAME}" --controller-namespace="${CONTROLLER_NAMESPACE}" \
+                 --format yaml ${CERT_ARG:+--cert=$CERT_ARG}


### PR DESCRIPTION
## What

Models the secret workflow on `../sms-api` so plaintext secrets live in a **gitignored, per-overlay `secrets.dat`** (documented by a committed `secrets.dat.template`) instead of being stashed ad-hoc in `~/.ssh`.

Each deploy overlay (`biosim-gke`, `biosim-rke`, `biosim-local`) gains:

- **`secrets.dat.template`** (committed) — documents the required keys: `MONGODB_URI`, `GCS_CREDENTIALS_FILE`, `GH_USER_NAME/EMAIL/PAT`, and optional kubeseal targeting, with per-cluster notes.
- **`secrets.sh`** (committed) — sources `secrets.dat`, errors helpfully if it's missing, and regenerates that overlay's `secret-shared.yaml` + `secret-ghcr.yaml` via the shared building-block scripts.
- **`secrets.dat`** — gitignored (`kustomize/overlays/**/secrets.dat`). Plaintext lives only here.

**Workflow:** `cp secrets.dat.template secrets.dat` → fill in → `./secrets.sh` → review + commit the regenerated `secret-*.yaml`.

## Building-block scripts

`sealed_secret_shared.sh` and `sealed_secret_ghcr.sh` gain `--controller-name` / `--controller-namespace` (so RKE/local seal against the in-cluster controller with no cert file), keeping `--cert` for GKE. **Backward-compatible** — existing invocations still work.

## Local dev (hosted Mongo URI)

`MONGODB_URI` is now a documented key, and `backend/.env.example` shows how to point local `MONGODB_URI`/`MONGODB_DATABASE` at the hosted read-only `biosimulations-prod` for project search API work. Adds a **Secrets** section to the root `CLAUDE.md`.

## Verification

- Bash syntax clean on all 5 scripts; `secrets.dat` gitignored, `secrets.dat.template` tracked.
- Missing-`secrets.dat` → friendly error + exit 1.
- Functional run (stubbed `kubeseal`, real `kubectl --dry-run`): `secrets.sh` sources values, passes controller flags through, and produces correctly-structured `SealedSecret`s (`shared-secrets` with `mongodb-uri`+`gcs_credentials.json`; `ghcr-secret` with `.dockerconfigjson`). **Committed sealed YAMLs left untouched** — nothing re-sealed.
- `kubectl kustomize` builds all three overlays.

No secret values are committed; only templates and tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm