### PR TITLE
Fix SLURM submit: valid partition/QOS + unbound-result error handler

### DIFF
--- a/backend/biosim_server/common/ssh/ssh_service.py
+++ b/backend/biosim_server/common/ssh/ssh_service.py
@@ -29,10 +29,12 @@ class SSHService:
                                 f"stdout={result.stdout[:100]} stderr={result.stderr[:100]}")
                 return result.returncode, result.stdout, result.stderr
             except asyncssh.ProcessError as exc:
-                logger.error(msg=f"failed to send command {command}, stderr {str(result.stderr)[:100]}", exc_info=exc)
+                # `result` is unbound here: conn.run(check=True) raises before it
+                # is assigned. The ProcessError carries the failed command's stderr.
+                logger.error(msg=f"failed to send command {command}, stderr {str(exc.stderr)[:100]}", exc_info=exc)
                 raise exc
             except (OSError, asyncssh.Error) as exc:
-                logger.error(msg=f"failed to send command {command}, stderr {str(result.stderr)[:100]}", exc_info=exc)
+                logger.error(msg=f"failed to send command {command}", exc_info=exc)
                 raise exc
 
     async def scp_upload(self, local_file: Path, remote_path: Path) -> None:

--- a/backend/tests/fixtures/slurm_fixtures.py
+++ b/backend/tests/fixtures/slurm_fixtures.py
@@ -33,8 +33,8 @@ def slurm_template_hello() -> str:
 # SBATCH --chdir=workDirname_1         # Working directory
 #SBATCH --output=output.txt           # Standard output file
 #SBATCH --error=error.txt             # Standard error file
-#SBATCH --partition=general           # Partition or queue name
-#SBATCH --qos=general                 # QOS level
+#SBATCH --partition=vcell             # Partition or queue name
+#SBATCH --qos=vcell-services          # QOS level
 #SBATCH --nodes=1                     # Number of nodes
 #SBATCH --ntasks-per-node=1           # Number of tasks per node
 #SBATCH --cpus-per-task=1             # Number of CPU cores per task


### PR DESCRIPTION
## What

Two related fixes surfaced while diagnosing the failing live SLURM submit test.

### 1. Valid partition / QOS in the test sbatch template
The `slurm_template_hello` fixture hardcoded `--partition=general` / `--qos=general`, which `sbatch` rejects for the `crbmapi` user on `hamantis` (exit 1). Switched to **`--partition=vcell`** / **`--qos=vcell-services`**, which are valid for that user. `sbatch --parsable` now returns exit 0 with a real job id and `test_slurm_job_submit` passes.

### 2. Unbound-`result` bug in `SSHService.run_command`
Both `except` handlers logged `result.stderr`, but `result` is unbound when `conn.run(check=True)` raises — so a non-zero remote exit surfaced as an `UnboundLocalError` that **swallowed the real `sbatch` stderr** (which is what made #1 hard to diagnose). The `ProcessError` handler now reads `exc.stderr`; the connection-error handler (`OSError`/`asyncssh.Error`, which carry no command stderr) just logs the command.

## Verification
- `uv run ruff check` + `uv run mypy` on the touched files — clean.
- `uv run pytest tests/common/test_slurm_service.py::test_slurm_job_submit` — passes (submits job `2406286` on `hamantis`).
- Note: this test is `skipif`-guarded on `slurm_submit_key`, so it runs locally (with the key + VPN) but is skipped in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm