### PR TITLE
Make SLURM partition/QOS configurable with vcell defaults

### DIFF
--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -58,9 +58,13 @@ class Settings(BaseSettings):
     biosimulators_api_base_url: str = "https://api.biosimulators.org"
     biosimulations_api_base_url: str = "https://api.biosimulations.org"
 
-    slurm_submit_host: str = ""   # "mantis-sub-1.cam.uchc.edu"
+    slurm_submit_host: str = ""   # "hamantis.cam.uchc.edu"
     slurm_submit_user: str = ""   # "crbmapi"
     slurm_submit_key: str = ""    # "/Users/jimschaff/.ssh/crbmapi"
+    # sbatch scheduling. Defaults are valid for the crbmapi user on hamantis;
+    # override per deployment. sbatch templates read these instead of hardcoding.
+    slurm_submit_partition: str = "vcell"
+    slurm_submit_qos: str = "vcell-services"
 
 
 @lru_cache

--- a/backend/tests/fixtures/slurm_fixtures.py
+++ b/backend/tests/fixtures/slurm_fixtures.py
@@ -27,14 +27,15 @@ async def slurm_service(ssh_service: SSHService) -> AsyncGenerator[SlurmService]
 
 @pytest.fixture(scope="session")
 def slurm_template_hello() -> str:
+    settings = get_settings()
     template = \
-"""#!/bin/bash
+f"""#!/bin/bash
 #SBATCH --job-name=my_test_job        # Job name
 # SBATCH --chdir=workDirname_1         # Working directory
 #SBATCH --output=output.txt           # Standard output file
 #SBATCH --error=error.txt             # Standard error file
-#SBATCH --partition=vcell             # Partition or queue name
-#SBATCH --qos=vcell-services          # QOS level
+#SBATCH --partition={settings.slurm_submit_partition}             # Partition or queue name
+#SBATCH --qos={settings.slurm_submit_qos}          # QOS level
 #SBATCH --nodes=1                     # Number of nodes
 #SBATCH --ntasks-per-node=1           # Number of tasks per node
 #SBATCH --cpus-per-task=1             # Number of CPU cores per task


### PR DESCRIPTION
## What

Adds `slurm_submit_partition` (default `vcell`) and `slurm_submit_qos` (default `vcell-services`) settings, overridable via `SLURM_SUBMIT_PARTITION` / `SLURM_SUBMIT_QOS`. The sbatch template reads them from config instead of hardcoding, so the scheduling target is set once and can be overridden per deployment.

sbatch isn't used in production yet — these config fields are the source of truth for the live SLURM test today and for any future production sbatch template, so the vcell defaults live in one place rather than scattered across templates.

Also refreshes the stale `slurm_submit_host` example comment (`mantis-sub-1` → `hamantis.cam.uchc.edu`).

## Verification

- `uv run ruff check` + `uv run mypy` on the touched files — clean.
- `uv run pytest tests/common/test_slurm_service.py::test_slurm_job_submit` — passes with the config default, submitting a real job on `hamantis`.
- The test is `skipif`-guarded on `slurm_submit_key`, so it runs locally (key + VPN) and is skipped in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm