### PR TITLE
Wire biosim-db page to platform /projects endpoints

### DIFF
--- a/frontend/app/models/projects.ts
+++ b/frontend/app/models/projects.ts
@@ -45,7 +45,7 @@ export interface ProjectSummary {
 }
 
 export interface ProjectStub {
-  id: number
+  id: string
   simulationRun: string
   created: string
   updated: string
@@ -53,5 +53,11 @@ export interface ProjectStub {
   summary: string
   model_format: string
   image_url: string | undefined
+}
+
+// Response of GET /projects (platform backend): a page of results + total count.
+export interface ProjectStubPage {
+  items: ProjectStub[]
+  total: number
 }
 // </editor-fold>

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -6,7 +6,7 @@ import {DotLottieVue} from "@lottiefiles/dotlottie-vue";
 import type {BreadcrumbItem} from "#ui/components/Breadcrumb.vue";
 import {normalize_text} from "~/functions/functions";
 import type {TableFilter, TableFilterConfig, TablePagination} from "~/models/filtering";
-import type {ProjectQueryStat, ProjectQueryStatFilter, Projects, ProjectSearchFilter, ProjectStub,} from "~/models/projects";
+import type {ProjectQueryStat, ProjectQueryStatFilter, ProjectSearchFilter, ProjectStub, ProjectStubPage,} from "~/models/projects";
 import type {CoreRow} from "@tanstack/table-core"
 import type {AppChip} from "~/models/common";
 
@@ -231,42 +231,32 @@ async function fetch_projects() {
   const populated_filters = searched_filters.value.filter(filter => filter.allowable_values.length > 0)
 
   try {
-    const api_return = await $fetch(`${runtimeConfig.public.legacy_api_url}/projects/summary_filtered`, {
+    // Results: the platform backend already returns ProjectStub-shaped rows with
+    // image_url + model_format populated — no per-project /files call needed.
+    // Pagination is 1-indexed here; the table is 0-indexed, so add one.
+    const results = await $fetch(`${runtimeConfig.public.api_url}/projects`, {
       method: 'GET',
       query: {
         'searchTerm': fuzzy_search_term.value,
-        'filters': [populated_filters],
-        'pageSize': table_pagination.value.perPage,
-        'pageIndex': table_pagination.value.page
+        'filters': JSON.stringify(populated_filters),
+        'perPage': table_pagination.value.perPage,
+        'page': table_pagination.value.page + 1
       }
-    }) as Projects
+    }) as ProjectStubPage
 
-    projects.value = await Promise.all(
-      api_return.projectSummaries.map(async (p: any) => {
-        const files = await $fetch(`${runtimeConfig.public.legacy_api_url}/files/${p.simulationRun.id}`, {})
+    projects.value = results.items
+    total_results.value = results.total
 
-        const image_url = (files as any[])
-          .find(f =>
-            f.name.endsWith('.png')
-            || f.name.endsWith('.jpg')
-            || f.name.endsWith('.jpeg')
-          )?.url
+    // Facet counts come from a separate endpoint. Pass only the search term (not
+    // the active filters) so the facet menu stays stable as filters are toggled.
+    const query_stats = await $fetch(`${runtimeConfig.public.api_url}/projects/stats`, {
+      method: 'GET',
+      query: {
+        'searchTerm': fuzzy_search_term.value
+      }
+    }) as ProjectQueryStat[]
 
-        return {
-          id: p.id,
-          name: p.simulationRun.metadata[0].title,
-          summary: p.simulationRun.metadata[0].abstract ? p.simulationRun.metadata[0].abstract.substring(0, 150) + '...' : '',
-          created: p.created,
-          updated: p.updated,
-          simulationRun: p.simulationRun.id,
-          image_url,
-          model_format: p.model_format
-        } as ProjectStub
-      })
-    ) as ProjectStub[]
-
-    total_results.value = api_return.totalMatchingProjectSummaries
-    filter_suggestions.value = query_stats_to_filter_groups(api_return.queryStats)
+    filter_suggestions.value = query_stats_to_filter_groups(query_stats)
     searched_filters.value = filter_suggestions.value.map((f, _index) => ({ target: f.target, allowable_values: []}))
 
     return


### PR DESCRIPTION
Points `biosim-db.vue` at the platform backend's project search API (now live on 0.7.0) instead of the legacy biosimulations.org API. Minimal change — the endpoint contract matches what the page already renders.

## Changes
- **`GET /projects`** (`runtimeConfig.public.api_url`) replaces `legacy_api_url/projects/summary_filtered`. Rows come back `ProjectStub`-shaped with **`image_url` and `model_format` already populated**, so the per-project **`/files` fetch (N+1) and the row `.map()` are removed**.
- **`GET /projects/stats`** supplies facet counts (passed only `searchTerm`, not the active filters, so the facet menu stays stable as filters toggle).
- **Pagination:** the API is 1-indexed, the table is 0-indexed → send `page + 1`.
- **`ProjectStub.id` → `string`** (project ids are slugs); added `ProjectStubPage`.

## Notes for review (@Harrison)
- Summaries are cleaned **server-side** in 0.7.0 (HTML stripped + truncated), so there's no client-side stripping here.
- `$text` search is whole-token (stemmed) + ranked, not substring — e.g. a partial word like "Edels" won't match "Edelstein1996"; a whole word will. Keyword and taxon labels are searchable.
- I couldn't run `npm run typecheck` locally (my Node/`@nuxt/image` install is broken); ESLint is clean on the changed files and `frontend-ci` will run the full typecheck here.

Verified against the live API: `GET https://api.biosim.biosimulations.org/projects?searchTerm=yeast%20cell%20cycle` ranks the Irons model #1 with clean plain-text summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm