### PR TITLE
bump-backend.sh: keep uv.lock version in lockstep

### DIFF
--- a/backend/scripts/bump-backend.sh
+++ b/backend/scripts/bump-backend.sh
@@ -18,8 +18,9 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 VERSION_PY="$REPO_ROOT/backend/biosim_server/version.py"
 PYPROJECT="$REPO_ROOT/backend/pyproject.toml"
+UVLOCK="$REPO_ROOT/backend/uv.lock"
 
-for f in "$VERSION_PY" "$PYPROJECT"; do
+for f in "$VERSION_PY" "$PYPROJECT" "$UVLOCK"; do
   [[ -f "$f" ]] || { echo "error: $f not found" >&2; exit 1; }
 done
 
@@ -56,7 +57,12 @@ printf '__version__ = "%s"' "$NEW" > "$VERSION_PY"
 # pyproject.toml: bump the [project] version line.
 perl -0pi -e "s/^version = \"\Q$OLD\E\"/version = \"$NEW\"/m" "$PYPROJECT"
 
-git -C "$REPO_ROOT" add "$VERSION_PY" "$PYPROJECT"
+# uv.lock: keep the biosim-server package entry's version in lockstep with
+# pyproject (it's package=false, so this is the only reference and no re-resolve
+# is needed). Replaces whatever version is there, so it also fixes prior drift.
+perl -0pi -e "s/(\nname = \"biosim-server\"\nversion = \")[^\"]*(\")/\${1}$NEW\${2}/" "$UVLOCK"
+
+git -C "$REPO_ROOT" add "$VERSION_PY" "$PYPROJECT" "$UVLOCK"
 git -C "$REPO_ROOT" commit -m "Bump backend to $NEW"
 git -C "$REPO_ROOT" tag "$TAG"
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "biosim-server"
-version = "0.6.0"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
The 0.6.0 and 0.7.0 bumps updated `version.py` + `pyproject.toml` but not `uv.lock`'s own `biosim-server` version entry, leaving it stale. It's harmless at build time (`package = false` means `uv sync --frozen` doesn't enforce the project's own version — which is why the 0.6.0/0.7.0 image builds still passed), but it's confusing and reappears as a stray diff on every `uv` run.

- **`bump-backend.sh`** now also rewrites the `biosim-server` version in `uv.lock` (a targeted `perl` on the package block — no re-resolve, so no dependency churn) and stages it alongside `version.py`/`pyproject.toml`. It replaces whatever version is present, so it **self-heals** any prior drift on the next bump.
- **Syncs the current `uv.lock` to 0.7.0** to clear the existing drift now (single-line change, no dep churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm