### PR TITLE
Weekly project-search reindex CronJob + lock down reindex endpoint

### DIFF
--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -65,6 +65,12 @@ class Settings(BaseSettings):
         "keywords": 4,
         "taxa": 3,
     }
+    # Bearer token required to call POST /projects/reindex. Empty (default)
+    # disables the endpoint entirely — the routine rebuild runs as an in-cluster
+    # CronJob (direct Mongo, no token), and admins can reindex via
+    # `python -m biosim_server.projects.reindex_cli`. Set a token only to enable
+    # ad-hoc HTTP-triggered reindexing.
+    project_reindex_token: str = ""
     # Legacy pre-2022 materialized summary; dead/abandoned (nothing writes it).
     # Kept only for reference — the API assembles from Projects + Metadata live.
     mongodb_collection_project_summary: str = "projectSummary"

--- a/backend/biosim_server/projects/reindex_cli.py
+++ b/backend/biosim_server/projects/reindex_cli.py
@@ -1,0 +1,38 @@
+"""One-shot reindex of the platform project search collection.
+
+Run in-cluster (e.g. the weekly CronJob, or ``kubectl exec ... python -m
+biosim_server.projects.reindex_cli`` for an ad-hoc admin reindex). Connects to
+Mongo directly and rebuilds ``PlatformProjectSearch`` from Projects + Metadata +
+Specifications — no HTTP endpoint or token involved.
+"""
+
+import asyncio
+import logging
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from biosim_server.config import get_settings
+from biosim_server.log_config import setup_logging
+from biosim_server.projects.search import ProjectSearchServiceMongo
+
+logger = logging.getLogger(__name__)
+
+
+async def _reindex() -> int:
+    client = AsyncIOMotorClient(get_settings().mongodb_uri)
+    service = ProjectSearchServiceMongo(db_client=client)
+    try:
+        count = await service.rebuild_index()
+    finally:
+        await service.close()
+    return count
+
+
+def main() -> None:
+    setup_logging(logger)
+    count = asyncio.run(_reindex())
+    logger.info(f"project search reindex complete: {count} documents")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/biosim_server/projects/router.py
+++ b/backend/biosim_server/projects/router.py
@@ -8,9 +8,10 @@ so paging through slim results is independent of the heavier facet computation
 import json
 import logging
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import ValidationError
 
+from biosim_server.config import get_settings
 from biosim_server.dependencies import get_project_database_service
 from biosim_server.projects.models import (
     ProjectQueryStat,
@@ -21,6 +22,19 @@ from biosim_server.projects.models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
+
+
+def require_reindex_token(authorization: str | None = Header(default=None)) -> None:
+    """Guard POST /projects/reindex with a bearer token.
+
+    Disabled by default: with no token configured the endpoint returns 503, so
+    it can't be triggered over the public ingress. The routine rebuild runs as an
+    in-cluster CronJob (direct Mongo), not through this endpoint."""
+    token = get_settings().project_reindex_token
+    if not token:
+        raise HTTPException(status_code=503, detail="reindex endpoint disabled (no token configured)")
+    if authorization != f"Bearer {token}":
+        raise HTTPException(status_code=401, detail="invalid or missing reindex token")
 
 
 def _parse_filters(filters_json: str) -> list[ProjectSearchFilter]:
@@ -68,6 +82,7 @@ async def list_projects(
 @router.post(
     "/reindex",
     operation_id="reindex-projects",
+    dependencies=[Depends(require_reindex_token)],
     summary="Rebuild the platform project search index from source collections",
 )
 async def reindex_projects() -> dict[str, int]:

--- a/backend/tests/projects/test_project_search.py
+++ b/backend/tests/projects/test_project_search.py
@@ -326,3 +326,32 @@ def test_endpoint_stats_shape(mock_get_db: MagicMock) -> None:
     body = resp.json()
     assert body[0]["target"] == "taxa"
     assert body[0]["valueFrequencies"][0] == {"value": "Human", "count": 2}
+
+
+@patch("biosim_server.projects.router.get_settings")
+def test_reindex_disabled_without_token(mock_settings: MagicMock) -> None:
+    mock_settings.return_value = MagicMock(project_reindex_token="")
+    client = TestClient(app)
+    assert client.post("/projects/reindex").status_code == 503
+
+
+@patch("biosim_server.projects.router.get_project_database_service")
+@patch("biosim_server.projects.router.get_settings")
+def test_reindex_requires_valid_token(mock_settings: MagicMock, mock_get_db: MagicMock) -> None:
+    mock_settings.return_value = MagicMock(project_reindex_token="s3cret")
+    mock_get_db.return_value = AsyncMock()
+    client = TestClient(app)
+    assert client.post("/projects/reindex").status_code == 401  # no header
+    assert client.post("/projects/reindex", headers={"Authorization": "Bearer wrong"}).status_code == 401
+
+
+@patch("biosim_server.projects.router.get_project_database_service")
+@patch("biosim_server.projects.router.get_settings")
+def test_reindex_valid_token_rebuilds(mock_settings: MagicMock, mock_get_db: MagicMock) -> None:
+    mock_settings.return_value = MagicMock(project_reindex_token="s3cret")
+    db = AsyncMock()
+    db.rebuild_index = AsyncMock(return_value=7)
+    mock_get_db.return_value = db
+    client = TestClient(app)
+    resp = client.post("/projects/reindex", headers={"Authorization": "Bearer s3cret"})
+    assert resp.status_code == 200 and resp.json() == {"indexed": 7}

--- a/docs/search-engine-meilisearch-design.md
+++ b/docs/search-engine-meilisearch-design.md
@@ -71,6 +71,20 @@ Either way the query lives behind the existing `ProjectDatabaseService` interfac
 (swap-in impl, no router change). 1B adds a `mongodb_collection_project_search`
 setting + a refresh entrypoint; 1A adds a text-index name only.
 
+### Operations (1B, implemented)
+The materialized collection is a point-in-time snapshot, so it needs refreshing —
+though the source `Projects` collection has been static for 17+ months, so this
+is a safety net more than a live need.
+- **Weekly reindex CronJob** (`kustomize/base/reindex-cronjob.yaml`) runs
+  `python -m biosim_server.projects.reindex_cli` (direct Mongo, no HTTP) in the
+  api image. It also absorbs any enrichment/index-logic change shipped since the
+  last run, so deploys don't require a manual reindex.
+- **`POST /projects/reindex` is token-gated** (`project_reindex_token`; empty
+  default = disabled/503) so it can't be triggered over the public ingress.
+  Ad-hoc admin reindex: `kubectl exec … python -m biosim_server.projects.reindex_cli`.
+- Rebuild is non-atomic (delete + insert ~1392 docs, ~1-2s window); acceptable
+  given how rarely it runs. Build-to-temp + swap is a future refinement.
+
 ---
 
 ## Phase 2 — self-hosted Meilisearch

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - api.yaml
   - worker.yaml
   - mongodb.yaml
+  - reindex-cronjob.yaml
   - frontend/

--- a/kustomize/base/reindex-cronjob.yaml
+++ b/kustomize/base/reindex-cronjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: project-search-reindex
+  labels:
+    app: project-search-reindex
+spec:
+  # Weekly, Sundays 03:00. The source project data changes rarely; this is a
+  # freshness safety net that also picks up any enrichment/index-logic change
+  # shipped since the last run, so deploys don't need a manual reindex.
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: project-search-reindex
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: reindex
+              # Same image as the api; the overlay `images:` transformer keeps
+              # the tag in lockstep with platform-api.
+              image: ghcr.io/biosimulations/platform-api:latest
+              imagePullPolicy: Always
+              command: ["python", "-m", "biosim_server.projects.reindex_cli"]
+              envFrom:
+                - configMapRef:
+                    name: api-config
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-secrets
+                      key: mongodb-uri
+          imagePullSecrets:
+            - name: ghcr-secret


### PR DESCRIPTION
Operational follow-up for Phase 1 search. The materialized `PlatformProjectSearch` collection is a snapshot; this keeps it fresh and closes the open reindex endpoint. (The source `Projects` data has been static 17+ months, so this is a safety net more than a live need.)

## Weekly reindex
- **`kustomize/base/reindex-cronjob.yaml`** — CronJob (Sundays 03:00) running `python -m biosim_server.projects.reindex_cli` in the api image. The overlay `images:` transformer keeps its tag in lockstep with `platform-api`. Uses the same `api-config` + `shared-secrets/mongodb-uri` wiring as the api; no storage/GCS needed.
- **`reindex_cli.py`** — new module: connects to Mongo directly and rebuilds the index (no HTTP, no token). Also usable ad-hoc: `kubectl exec … python -m biosim_server.projects.reindex_cli`.
- The weekly run also **absorbs any enrichment/index-logic change** shipped since the last run, so deploys no longer need a manual `POST /projects/reindex`.

## Lock down the endpoint
- **`POST /projects/reindex` is now bearer-token gated** (`project_reindex_token`; **empty default = disabled → 503**), so it can't be triggered over the public ingress. Wrong/missing token → 401.

## Verification
- 32 projects tests incl. reindex `503` (disabled), `401` (bad token), `200` (valid token + rebuild); ruff + mypy clean.
- `kubectl kustomize` on the gke overlay includes the CronJob at `platform-api:backend-0.7.0` with the `reindex_cli` command.

Takes effect on the next backend release/deploy (the CronJob needs the image that contains `reindex_cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm