### PR TITLE
Fix circular import breaking the reindex CLI

### DIFF
--- a/backend/biosim_server/api/main.py
+++ b/backend/biosim_server/api/main.py
@@ -17,7 +17,7 @@ from biosim_server.biosim_runs import BiosimulatorVersion
 from biosim_server.biosim_verify import CompareSettings
 from biosim_server.compatibility import compatibility_router
 from biosim_server.simulations import simulations_router
-from biosim_server.projects import projects_router
+from biosim_server.projects.router import router as projects_router
 from biosim_server.biosim_verify.models import VerifyWorkflowOutput, VerifyWorkflowStatus
 from biosim_server.biosim_verify.omex_verify_workflow import OmexVerifyWorkflow, OmexVerifyWorkflowInput
 from biosim_server.biosim_verify.runs_verify_workflow import RunsVerifyWorkflowInput, RunsVerifyWorkflow

--- a/backend/biosim_server/projects/__init__.py
+++ b/backend/biosim_server/projects/__init__.py
@@ -11,7 +11,11 @@ from biosim_server.projects.models import (
     ProjectStubPage,
     ValueFrequency,
 )
-from biosim_server.projects.router import router as projects_router
+# NOTE: the FastAPI router is intentionally NOT re-exported here. It pulls in
+# `dependencies` (and transitively `biosim_runs`), whose import order only
+# resolves when the app boots via api.main. Importing this package for its
+# data/search classes (e.g. the reindex CLI) must stay free of that chain, so
+# import the router directly from `biosim_server.projects.router` where needed.
 
 __all__ = [
     "ProjectDatabaseService",
@@ -23,5 +27,4 @@ __all__ = [
     "ProjectStub",
     "ProjectStubPage",
     "ValueFrequency",
-    "projects_router",
 ]


### PR DESCRIPTION
`python -m biosim_server.projects.reindex_cli` (the weekly reindex CronJob added in 0.8.0) failed with an `ImportError`: importing the `projects` package runs its `__init__`, which imported the FastAPI router → `dependencies` → `biosim_runs` → back into partially-initialized `dependencies`. Masked when the app boots via `api.main` (which imports `biosim_runs` first), but the CLI enters through the `projects` package and trips the cycle.

**Fix:** stop re-exporting the router from `projects/__init__.py` (the only thing dragging in `dependencies`) and import it directly in `api.main`. The `projects` package's data/search classes are now importable free of the FastAPI/dependencies chain.

Caught by manually triggering the CronJob against the 0.8.0 deploy (it exited 1). Ships as 0.8.1.

Verified: `reindex_cli` imports cleanly, app still wires all 3 `/projects` routes, 32 projects tests pass, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm