### PR TITLE
Expose biosimulationsRunId on /simulations/runs

### DIFF
--- a/backend/biosim_server/simulations/models.py
+++ b/backend/biosim_server/simulations/models.py
@@ -103,6 +103,11 @@ class SimulationRun(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
+    # The biosimulations.org run id (24-char Mongo ObjectId). `id` above is our
+    # internal per-simulator run_id (a 32-char uuid4 hex); detail pages that fetch
+    # from the biosimulations API must key off this, not `id`. None until the run
+    # has been submitted to biosimulations and assigned an id.
+    biosimulations_run_id: str | None = Field(default=None, serialization_alias="biosimulationsRunId")
     name: str
     simulator: str
     simulator_version: str = Field(serialization_alias="simulatorVersion")
@@ -124,6 +129,7 @@ class SimulationRun(BaseModel):
     def from_record(cls, record: SimulationRunRecord) -> "SimulationRun":
         return cls(
             id=record.run_id,
+            biosimulations_run_id=record.biosimulations_run_id,
             name=record.name,
             simulator=record.simulator,
             simulator_version=record.simulator_version,

--- a/backend/tests/simulations/test_runs_query.py
+++ b/backend/tests/simulations/test_runs_query.py
@@ -33,6 +33,7 @@ def _record(
     status: str = "CREATED",
     cache_buster: str = "0",
     submitted: datetime | None = None,
+    biosimulations_run_id: str | None = None,
 ) -> SimulationRunRecord:
     when = submitted or datetime(2024, 1, 1, tzinfo=timezone.utc)
     return SimulationRunRecord(
@@ -47,6 +48,7 @@ def _record(
         status=status,  # type: ignore[arg-type]
         submitted=when,
         updated=when,
+        biosimulations_run_id=biosimulations_run_id,
     )
 
 
@@ -211,7 +213,8 @@ def test_endpoint_service_unavailable(mock_get_runs_db: MagicMock) -> None:
 @patch("biosim_server.simulations.router.get_simulation_run_database_service")
 def test_endpoint_success_shape(mock_get_runs_db: MagicMock) -> None:
     runs_db = AsyncMock()
-    runs_db.query_simulation_runs.return_value = ([_record("a", status="SUCCEEDED")], 1)
+    runs_db.query_simulation_runs.return_value = (
+        [_record("a", status="SUCCEEDED", biosimulations_run_id="6a3d5603015a4d8b0bf24b74")], 1)
     mock_get_runs_db.return_value = runs_db
 
     client = TestClient(app)
@@ -223,7 +226,9 @@ def test_endpoint_success_shape(mock_get_runs_db: MagicMock) -> None:
     assert body["pagination"] == {"page": 1, "perPage": 20, "_total": 1}
     assert len(body["runs"]) == 1
     run = body["runs"][0]
-    assert run["id"] == "a"
+    assert run["id"] == "a"  # internal run_id (per-simulator job)
+    # the biosimulations ObjectId detail pages must key off, exposed separately
+    assert run["biosimulationsRunId"] == "6a3d5603015a4d8b0bf24b74"
     assert run["status"] == "SUCCEEDED"
     assert run["simulatorVersion"] == "1.0.0"
     assert run["simulatorDigest"] == "sha256:abc"


### PR DESCRIPTION
**Bug (reported by Harrison, blocks the runs detail pages for the CRBM demo):** `GET/POST /simulations/runs` returns `id` = our internal per-simulator `run_id` (a 32-char `uuid4` hex, e.g. `5a6d7a55…`). The detail page (`/runs/[id].vue`) fetches from the biosimulations API, which uses 24-char ObjectIds — so linking off `id` 404s.

The record already has the biosimulations ObjectId (`biosimulations_run_id`, e.g. the SUCCEEDED vcell run → `6a3d5603015a4d8b0bf24b74`); the API just never exposed it.

**Fix:** add `biosimulationsRunId` to the `SimulationRun` response (from `record.biosimulations_run_id`; `null` until the run is submitted to biosimulations and assigned an id). `id` stays the internal `run_id` (unique per-simulator row key).

**Frontend follow-up (Harrison):** link the detail page off `run.biosimulationsRunId` instead of `run.id`, and add the field to the `SimulationRun` type in `frontend/app/models/simulators.ts`.

Verified: 15 runs-query tests (incl. the new field surfacing); ruff + mypy clean. Confirmed against live data that the ObjectIds are present in `BiosimSimulationRuns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm