### PR TITLE
Expand project search facets to the legacy category set

### DIFF
--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     mongodb_collection_projects: str = "Projects"
     mongodb_collection_metadata: str = "Metadata"
     mongodb_collection_specifications: str = "Specifications"
+    # biosimulations per-run records (note the space); source of the `simulator`
+    # facet. Keyed by `id` == a project's `simulationRun`.
+    mongodb_collection_biosimulations_runs: str = "Simulation Runs"
     # Platform-owned materialized search collection (Phase 1 $text). Built by
     # reading the biosimulations collections above; we own its $text index. The
     # "Platform" prefix keeps it clearly ours, not a biosimulations collection.
@@ -64,6 +67,10 @@ class Settings(BaseSettings):
         "description": 1,
         "keywords": 4,
         "taxa": 3,
+        "biology": 4,
+        "modelFormats": 3,
+        "simulationTypes": 2,
+        "simulator": 3,
     }
     # Bearer token required to call POST /projects/reindex. Empty (default)
     # disables the endpoint entirely — the routine rebuild runs as an in-cluster

--- a/backend/biosim_server/projects/search.py
+++ b/backend/biosim_server/projects/search.py
@@ -26,11 +26,11 @@ from typing_extensions import override
 from biosim_server.config import get_settings
 from biosim_server.projects.database import (
     ProjectDatabaseService,
+    _format_from_language_urn,
     _image_url,
     _join_stages,
     _label_values,
     _META,
-    _model_format,
     _MODELS,
     _TtlCache,
 )
@@ -43,9 +43,16 @@ from biosim_server.projects.models import (
 
 logger = logging.getLogger(__name__)
 
-# Facet targets are flat top-level array fields on the search document (unlike the
-# nested `_meta0.<field>` paths of the live-aggregation path).
-_FACET_TARGETS = ("taxa", "keywords")
+# Facet targets are flat top-level array fields on the search document. Mirrors
+# the legacy biosimulations project facets (project-utils.ts getProjectSummary_*),
+# materialized here at index time. (simulationAlgorithms is omitted for now — it
+# needs the KISAO id->name map, which lives behind the compatibility package.)
+_FACET_TARGETS = ("taxa", "keywords", "biology", "modelFormats", "simulationTypes", "simulator", "reports")
+
+# Projected enrichment fields (from Specifications / the run doc).
+_SIMULATIONS = "_simulations"
+_OUTPUTS = "_outputs"
+_SIMULATOR = "_simulator"
 
 # Name of the (single) $text index; the searchable fields + weights come from
 # settings.project_search_text_weights.
@@ -83,6 +90,48 @@ def _summarize(text: str, limit: int = _SUMMARY_MAX) -> str:
     return text[:limit].rstrip() + "…"
 
 
+# Insert a space before each interior capital: "UniformTimeCourse" -> "Uniform Time Course".
+_CAMEL_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _sed_type_label(sed_type: Any) -> str:
+    """SED-ML simulation `_type` -> readable label, e.g.
+    ``SedUniformTimeCourseSimulation`` -> ``Uniform Time Course``."""
+    if not isinstance(sed_type, str) or not sed_type:
+        return ""
+    core = sed_type.removeprefix("Sed").removesuffix("Simulation")
+    return _CAMEL_RE.sub(" ", core).strip()
+
+
+def _distinct(values: list[str]) -> list[str]:
+    seen: dict[str, None] = {}
+    for v in values:
+        if v:
+            seen.setdefault(v, None)
+    return list(seen)
+
+
+def _model_formats(models: Any) -> list[str]:
+    """Distinct model-format acronyms across a run's SED-ML models (e.g. SBML)."""
+    if not isinstance(models, list):
+        return []
+    return _distinct([_format_from_language_urn(m.get("language")) for m in models if isinstance(m, dict)])
+
+
+def _simulation_types(simulations: Any) -> list[str]:
+    if not isinstance(simulations, list):
+        return []
+    return _distinct([_sed_type_label(s.get("_type")) for s in simulations if isinstance(s, dict)])
+
+
+def _reports(outputs: Any) -> list[str]:
+    """Legacy `reports` facet: whether the run produced a SED report."""
+    has = isinstance(outputs, list) and any(
+        isinstance(o, dict) and o.get("_type") == "SedReport" for o in outputs
+    )
+    return ["true"] if has else ["false"]
+
+
 def _search_document(doc: dict[str, Any], api_base: str) -> dict[str, Any]:
     """Build one flat, indexable search document from an enriched aggregation row.
 
@@ -95,6 +144,8 @@ def _search_document(doc: dict[str, Any], api_base: str) -> dict[str, Any]:
     title = _plain_text(meta.get("title"))
     abstract = _plain_text(meta.get("abstract"))
     description = _plain_text(meta.get("description"))
+    model_formats = _model_formats(doc.get(_MODELS))
+    simulator = doc.get(_SIMULATOR)
     return {
         "id": pid,
         "simulationRun": run,
@@ -103,15 +154,20 @@ def _search_document(doc: dict[str, Any], api_base: str) -> dict[str, Any]:
         "updated": doc.get("updated"),
         "name": title or pid,
         "summary": _summarize(abstract or description),
-        "model_format": _model_format(doc.get(_MODELS)),
+        "model_format": model_formats[0] if model_formats else "",  # stub display (first)
         "image_url": _image_url(run, meta.get("thumbnails"), api_base),
         # Searchable text (indexed), HTML-stripped.
         "title": title,
         "abstract": abstract,
         "description": description,
-        # Facets (filterable + counted).
+        # Facets (filterable + counted) — mirrors the legacy biosimulations set.
         "taxa": _label_values(meta.get("taxa")),
         "keywords": _label_values(meta.get("keywords")),
+        "biology": _label_values(meta.get("encodes")),
+        "modelFormats": model_formats,
+        "simulationTypes": _simulation_types(doc.get(_SIMULATIONS)),
+        "simulator": [str(simulator)] if simulator else [],
+        "reports": _reports(doc.get(_OUTPUTS)),
     }
 
 
@@ -151,6 +207,7 @@ class ProjectSearchServiceMongo(ProjectDatabaseService):
         self._search_col = database.get_collection(settings.mongodb_collection_project_search)
         self._metadata_collection_name = settings.mongodb_collection_metadata
         self._specifications_collection_name = settings.mongodb_collection_specifications
+        self._biosim_runs_collection_name = settings.mongodb_collection_biosimulations_runs
         self._api_base = settings.biosimulations_api_base_url.rstrip("/")
         self._stats_cache = _TtlCache(settings.project_stats_cache_ttl_seconds)
 
@@ -169,8 +226,30 @@ class ProjectSearchServiceMongo(ProjectDatabaseService):
                     "as": "_spec",
                 }
             },
-            {"$addFields": {_MODELS: {"$ifNull": [{"$arrayElemAt": ["$_spec.models", 0]}, []]}}},
-            {"$project": {"id": 1, "simulationRun": 1, "created": 1, "updated": 1, _META: 1, _MODELS: 1}},
+            {"$addFields": {"_spec0": {"$ifNull": [{"$arrayElemAt": ["$_spec", 0]}, {}]}}},
+            {
+                "$lookup": {
+                    # the biosimulations run record (keyed by `id`) carries the simulator
+                    "from": self._biosim_runs_collection_name,
+                    "localField": "simulationRun",
+                    "foreignField": "id",
+                    "as": "_run",
+                }
+            },
+            {"$addFields": {"_run0": {"$ifNull": [{"$arrayElemAt": ["$_run", 0]}, {}]}}},
+            {
+                "$project": {
+                    "id": 1,
+                    "simulationRun": 1,
+                    "created": 1,
+                    "updated": 1,
+                    _META: 1,
+                    _MODELS: "$_spec0.models",
+                    _SIMULATIONS: "$_spec0.simulations",
+                    _OUTPUTS: "$_spec0.outputs",
+                    _SIMULATOR: "$_run0.simulator",
+                }
+            },
         ]
         return stages
 
@@ -215,8 +294,8 @@ class ProjectSearchServiceMongo(ProjectDatabaseService):
                 weights=weights,
                 name=_TEXT_INDEX_NAME,
             )
-        await self._search_col.create_index("taxa")
-        await self._search_col.create_index("keywords")
+        for target in _FACET_TARGETS:
+            await self._search_col.create_index(target)
         await self._search_col.create_index([("updated", DESCENDING), ("id", ASCENDING)])
         await self._search_col.create_index("id", unique=True)
 
@@ -273,7 +352,7 @@ class ProjectSearchServiceMongo(ProjectDatabaseService):
             match["$text"] = {"$search": search_term}
 
         counts: dict[str, dict[str, int]] = {t: {} for t in _FACET_TARGETS}
-        cursor = self._search_col.find(match, {"taxa": 1, "keywords": 1})
+        cursor = self._search_col.find(match, {t: 1 for t in _FACET_TARGETS})
         async for doc in cursor:
             for target in _FACET_TARGETS:
                 for value in doc.get(target) or []:

--- a/backend/tests/fixtures/database_fixtures.py
+++ b/backend/tests/fixtures/database_fixtures.py
@@ -145,5 +145,6 @@ async def project_search_service_mongo(
     await projects_col.delete_many({})
     await metadata_col.delete_many({})
     await specifications_col.delete_many({})
+    await database.get_collection(settings.mongodb_collection_biosimulations_runs).delete_many({})
     await search_col.drop()
     set_project_database_service(old_projects_db_service)

--- a/backend/tests/projects/test_project_search_index.py
+++ b/backend/tests/projects/test_project_search_index.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
-from motor.motor_asyncio import AsyncIOMotorCollection
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 
 from biosim_server.projects import ProjectSearchServiceMongo
 from biosim_server.projects.models import ProjectSearchFilter
@@ -29,7 +29,7 @@ def _project(pid: str, run: str, updated: datetime | None = None) -> dict[str, A
 
 def _metadata(run: str, *, title: str, abstract: str = "", description: str = "",
               taxa: list[str] | None = None, keywords: list[str] | None = None,
-              thumbnails: list[str] | None = None) -> dict[str, Any]:
+              thumbnails: list[str] | None = None, encodes: list[str] | None = None) -> dict[str, Any]:
     item: dict[str, Any] = {"title": title, "abstract": abstract, "description": description}
     if taxa is not None:
         item["taxa"] = [{"uri": None, "label": t} for t in taxa]
@@ -37,11 +37,23 @@ def _metadata(run: str, *, title: str, abstract: str = "", description: str = ""
         item["keywords"] = keywords
     if thumbnails is not None:
         item["thumbnails"] = thumbnails
+    if encodes is not None:
+        item["encodes"] = [{"uri": None, "label": e} for e in encodes]
     return {"simulationRun": run, "metadata": [item]}
 
 
-def _spec(run: str, languages: list[str]) -> dict[str, Any]:
-    return {"simulationRun": run, "models": [{"language": lg} for lg in languages]}
+def _spec(run: str, languages: list[str], *, sim_types: list[str] | None = None,
+          report: bool = False) -> dict[str, Any]:
+    doc: dict[str, Any] = {"simulationRun": run, "models": [{"language": lg} for lg in languages]}
+    if sim_types is not None:
+        doc["simulations"] = [{"_type": t} for t in sim_types]
+    if report:
+        doc["outputs"] = [{"_type": "SedReport"}]
+    return doc
+
+
+def _run_doc(run: str, *, simulator: str) -> dict[str, Any]:
+    return {"id": run, "simulator": simulator}
 
 
 async def _seed_and_build(
@@ -223,9 +235,50 @@ async def test_ensure_indexes_rebuilds_text_index_on_change(project_search_servi
     # stand up an old-style index (title only)
     await search_col.create_index([("title", "text")], weights={"title": 1}, name="project_text")
     await svc.ensure_indexes()
+    from biosim_server.config import get_settings
+
     weights = (await search_col.index_information())["project_text"]["weights"]
-    assert set(weights.keys()) == {"title", "abstract", "description", "keywords", "taxa"}
+    assert set(weights.keys()) == set(get_settings().project_search_text_weights)  # rebuilt to config
     assert weights["title"] == 10 and weights["keywords"] == 4 and weights["taxa"] == 3
+
+
+@pytest.mark.asyncio
+async def test_expanded_legacy_facets(
+    project_search_service_mongo: Cols, mongo_test_client: AsyncIOMotorClient
+) -> None:
+    """biology/modelFormats/simulationTypes/simulator/reports facets materialize
+    from Metadata (encodes), Specifications (models/simulations/outputs) and the
+    Simulation Runs doc (simulator)."""
+    from biosim_server.config import get_settings
+
+    settings = get_settings()
+    svc, projects_col, metadata_col, specifications_col, search_col = project_search_service_mongo
+    runs_col = mongo_test_client.get_database(settings.mongodb_database).get_collection(
+        settings.mongodb_collection_biosimulations_runs)
+    await projects_col.insert_one(_project("p1", "r1"))
+    await metadata_col.insert_one(_metadata("r1", title="Model", encodes=["cell cycle"], taxa=["Yeast"]))
+    await specifications_col.insert_one(
+        _spec("r1", ["urn:sedml:language:sbml"], sim_types=["SedUniformTimeCourseSimulation"], report=True))
+    await runs_col.insert_one(_run_doc("r1", simulator="tellurium"))
+    await svc.rebuild_index()
+
+    doc = await search_col.find_one({"id": "p1"})
+    assert doc is not None
+    assert doc["biology"] == ["cell cycle"]
+    assert doc["modelFormats"] == ["SBML"]
+    assert doc["simulationTypes"] == ["Uniform Time Course"]
+    assert doc["simulator"] == ["tellurium"]
+    assert doc["reports"] == ["true"]
+
+    stats = await svc.query_project_stats(filters=[], search_term="")
+    targets = {s.target for s in stats}
+    assert {"biology", "modelFormats", "simulationTypes", "simulator", "reports", "taxa", "keywords"} <= targets
+
+    # searchable: a term only in a facet field (biology/simulator) still matches
+    by_biology, _ = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="cell cycle")
+    assert [s.id for s in by_biology] == ["p1"]
+    by_sim, _ = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="tellurium")
+    assert [s.id for s in by_sim] == ["p1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Grows the materialized `PlatformProjectSearch` facets from **taxa + keywords** to the legacy biosimulations set, extracted at index time into our own collection (reusing biosimulations' `getProjectSummary_*` extraction logic, not their query-time lucene index):

| facet | source |
|---|---|
| `biology` | `Metadata.encodes` labels |
| `modelFormats` | `Specifications.models[].language` (SED-ML URN → acronym) |
| `simulationTypes` | `Specifications.simulations[]._type` → readable label |
| `simulator` | the biosimulations **`Simulation Runs`** doc (new `$lookup` on run `id`) |
| `reports` | `Specifications.outputs[]` has a `SedReport` (true/false) |

- `biology` / `modelFormats` / `simulationTypes` / `simulator` are also added to the **`$text` searchable set** (config `project_search_text_weights`) for fuzzy ranking; `reports` is facet-only.
- `ensure_indexes` now indexes every facet field; the text-index drop-and-recreate handles the widened searchable set.
- **`simulationAlgorithms` deferred** — it needs the KISAO id→name map, which lives behind the `compatibility` package's `biosim_runs` import (would re-trigger the reindex-CLI circular import). Small follow-up to relocate that map.

## Validation (live prod data, 1392 projects)
- modelFormats: SBML 970 / CELLML 341 / XPP 74 / SMOLDYN / RBA / LEMS
- simulator: tellurium 395 / opencor 341 / copasi 264 / amici / cobrapy / xpp (16 distinct)
- simulationTypes: Uniform Time Course 1301 / Steady State 91
- biology: 169 projects, 329 distinct (metabolic process, action potentials, ion channels…)
- 33 projects tests; ruff + mypy clean.

Ships in the next release; takes effect after a reindex (the deploy CronJob/`POST /projects/reindex` rebuilds with the new fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzpYYAXPMj1SyxgWf9Lgtm