### PR TITLE
Fix broken KISAO import (api crashloop) + land simulationAlgorithms

### DIFF
--- a/backend/biosim_server/compatibility/simulator_matcher.py
+++ b/backend/biosim_server/compatibility/simulator_matcher.py
@@ -7,7 +7,7 @@ import aiohttp
 from aiocache import SimpleMemoryCache, cached  # type: ignore
 
 from biosim_server.biosim_runs import BiosimulatorVersion
-from biosim_server.compatibility.kisao_data import EQUIVALENCE_CATEGORIES, KISAO_TERMS
+from biosim_server.common.kisao_data import EQUIVALENCE_CATEGORIES, KISAO_TERMS
 from biosim_server.compatibility.models import EligibleSimulator, KisaoTerm, OmexContent, SimulatorVersionDetail
 from biosim_server.config import get_settings
 

--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -70,6 +70,7 @@ class Settings(BaseSettings):
         "biology": 4,
         "modelFormats": 3,
         "simulationTypes": 2,
+        "simulationAlgorithms": 2,
         "simulator": 3,
     }
     # Bearer token required to call POST /projects/reindex. Empty (default)

--- a/backend/biosim_server/projects/search.py
+++ b/backend/biosim_server/projects/search.py
@@ -23,6 +23,7 @@ from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pymongo import ASCENDING, DESCENDING, TEXT
 from typing_extensions import override
 
+from biosim_server.common.kisao_data import KISAO_TERMS
 from biosim_server.config import get_settings
 from biosim_server.projects.database import (
     ProjectDatabaseService,
@@ -47,7 +48,10 @@ logger = logging.getLogger(__name__)
 # the legacy biosimulations project facets (project-utils.ts getProjectSummary_*),
 # materialized here at index time. (simulationAlgorithms is omitted for now — it
 # needs the KISAO id->name map, which lives behind the compatibility package.)
-_FACET_TARGETS = ("taxa", "keywords", "biology", "modelFormats", "simulationTypes", "simulator", "reports")
+_FACET_TARGETS = (
+    "taxa", "keywords", "biology", "modelFormats",
+    "simulationTypes", "simulationAlgorithms", "simulator", "reports",
+)
 
 # Projected enrichment fields (from Specifications / the run doc).
 _SIMULATIONS = "_simulations"
@@ -124,6 +128,27 @@ def _simulation_types(simulations: Any) -> list[str]:
     return _distinct([_sed_type_label(s.get("_type")) for s in simulations if isinstance(s, dict)])
 
 
+def _kisao_name(kisao_id: Any) -> str:
+    """KISAO id -> algorithm name, falling back to the id. Specifications use the
+    underscore form (``KISAO_0000019``); KISAO_TERMS keys use the colon form."""
+    if not isinstance(kisao_id, str) or not kisao_id:
+        return ""
+    term = KISAO_TERMS.get(kisao_id.replace("KISAO_", "KISAO:", 1))
+    return term["name"] if term else kisao_id
+
+
+def _simulation_algorithms(simulations: Any) -> list[str]:
+    """Distinct SED-ML algorithm names (from each simulation's KISAO id)."""
+    if not isinstance(simulations, list):
+        return []
+    names: list[str] = []
+    for s in simulations:
+        algo = s.get("algorithm") if isinstance(s, dict) else None
+        if isinstance(algo, dict):
+            names.append(_kisao_name(algo.get("kisaoId")))
+    return _distinct(names)
+
+
 def _reports(outputs: Any) -> list[str]:
     """Legacy `reports` facet: whether the run produced a SED report."""
     has = isinstance(outputs, list) and any(
@@ -166,6 +191,7 @@ def _search_document(doc: dict[str, Any], api_base: str) -> dict[str, Any]:
         "biology": _label_values(meta.get("encodes")),
         "modelFormats": model_formats,
         "simulationTypes": _simulation_types(doc.get(_SIMULATIONS)),
+        "simulationAlgorithms": _simulation_algorithms(doc.get(_SIMULATIONS)),
         "simulator": [str(simulator)] if simulator else [],
         "reports": _reports(doc.get(_OUTPUTS)),
     }

--- a/backend/scripts/generate_kisao_data.py
+++ b/backend/scripts/generate_kisao_data.py
@@ -7,7 +7,7 @@ and generates a Python module containing term names and ancestor relationships.
 Usage:
     uv run python scripts/generate_kisao_data.py
 
-The output is written to biosim_server/compatibility/kisao_data.py
+The output is written to biosim_server/common/kisao_data.py
 """
 
 import asyncio
@@ -199,7 +199,7 @@ async def main() -> int:
     # Determine output path
     script_dir = Path(__file__).parent
     project_root = script_dir.parent
-    output_path = project_root / "biosim_server" / "compatibility" / "kisao_data.py"
+    output_path = project_root / "biosim_server" / "common" / "kisao_data.py"
 
     async with aiohttp.ClientSession() as session:
         # Fetch all terms

--- a/backend/tests/projects/test_project_search_index.py
+++ b/backend/tests/projects/test_project_search_index.py
@@ -43,10 +43,20 @@ def _metadata(run: str, *, title: str, abstract: str = "", description: str = ""
 
 
 def _spec(run: str, languages: list[str], *, sim_types: list[str] | None = None,
-          report: bool = False) -> dict[str, Any]:
+          algorithms: list[str] | None = None, report: bool = False) -> dict[str, Any]:
     doc: dict[str, Any] = {"simulationRun": run, "models": [{"language": lg} for lg in languages]}
-    if sim_types is not None:
-        doc["simulations"] = [{"_type": t} for t in sim_types]
+    types = sim_types or []
+    algos = algorithms or []
+    sims: list[dict[str, Any]] = []
+    for i in range(max(len(types), len(algos))):
+        s: dict[str, Any] = {}
+        if i < len(types):
+            s["_type"] = types[i]
+        if i < len(algos):
+            s["algorithm"] = {"kisaoId": algos[i]}
+        sims.append(s)
+    if sims:
+        doc["simulations"] = sims
     if report:
         doc["outputs"] = [{"_type": "SedReport"}]
     return doc
@@ -258,7 +268,8 @@ async def test_expanded_legacy_facets(
     await projects_col.insert_one(_project("p1", "r1"))
     await metadata_col.insert_one(_metadata("r1", title="Model", encodes=["cell cycle"], taxa=["Yeast"]))
     await specifications_col.insert_one(
-        _spec("r1", ["urn:sedml:language:sbml"], sim_types=["SedUniformTimeCourseSimulation"], report=True))
+        _spec("r1", ["urn:sedml:language:sbml"], sim_types=["SedUniformTimeCourseSimulation"],
+              algorithms=["KISAO_0000019"], report=True))  # KISAO:0000019 -> CVODE
     await runs_col.insert_one(_run_doc("r1", simulator="tellurium"))
     await svc.rebuild_index()
 
@@ -267,12 +278,14 @@ async def test_expanded_legacy_facets(
     assert doc["biology"] == ["cell cycle"]
     assert doc["modelFormats"] == ["SBML"]
     assert doc["simulationTypes"] == ["Uniform Time Course"]
+    assert doc["simulationAlgorithms"] == ["CVODE"]  # KISAO id resolved to name
     assert doc["simulator"] == ["tellurium"]
     assert doc["reports"] == ["true"]
 
     stats = await svc.query_project_stats(filters=[], search_term="")
     targets = {s.target for s in stats}
-    assert {"biology", "modelFormats", "simulationTypes", "simulator", "reports", "taxa", "keywords"} <= targets
+    assert {"biology", "modelFormats", "simulationTypes", "simulationAlgorithms",
+            "simulator", "reports", "taxa", "keywords"} <= targets
 
     # searchable: a term only in a facet field (biology/simulator) still matches
     by_biology, _ = await svc.query_project_stubs(page=1, per_page=10, filters=[], search_term="cell cycle")


### PR DESCRIPTION
**Incident fix.** #83 moved `kisao_data.py` to `common/` but a bad `git add` dropped the importer/feature edits, so `main` had the move without updating `simulator_matcher`'s import → `ModuleNotFoundError` → **api CrashLoopBackOff on 0.9.1** (rolled back to 0.9.0, service restored). It slipped through because #83 was admin-merged without CI.

Lands the missing edits: `simulator_matcher` + generator import/write the `common/` path; `search.py` gets the `simulationAlgorithms` facet (KISAO id→name) + config weight; test coverage.

Verified: `import biosim_server.api.main` succeeds (reproduced the exact crash), ruff + mypy clean, 55 tests. **Letting CI gate this one.**