### PR TITLE
Bump frontend to 0.1.1 (deploy current UI)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platform-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-frontend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@iconify-json/lucide": "^1.2.74",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kustomize/overlays/biosim-gke/kustomization.yaml
+++ b/kustomize/overlays/biosim-gke/kustomization.yaml
@@ -9,7 +9,7 @@ images:
 - name: ghcr.io/biosimulations/platform-worker
   newTag: backend-0.9.2
 - name: ghcr.io/biosimulations/platform-frontend
-  newTag: frontend-0.1.0
+  newTag: frontend-0.1.1
 - name: docker.io/library/mongo
   newTag: 8.0.4
 


### PR DESCRIPTION
The deployed frontend image (frontend-0.1.0) was built once early and never rebuilt; main's frontend has since evolved (biosim-db wired to /projects, runs page, etc.), so the live UI at /biosim-db is stale and errors. Bump to 0.1.1 and rebuild from current main. The release workflow runs npm ci + npm run build (validates the build).