### PR TITLE
fix: resolve OMEX manifest locations written with a "./" prefix

### DIFF
--- a/backend/biosim_server/compatibility/models.py
+++ b/backend/biosim_server/compatibility/models.py
@@ -25,6 +25,7 @@ class OmexContent(BaseModel):
     model_formats: list[ModelFormat]
     simulations: list[SimulationRequirement]
     sedml_files: list[str]
+    parse_errors: list[str] = []  # SED-ML files that could not be read or parsed
 
 
 class SimulatorVersionDetail(BaseModel):

--- a/backend/biosim_server/compatibility/omex_parser.py
+++ b/backend/biosim_server/compatibility/omex_parser.py
@@ -50,6 +50,46 @@ SIMULATION_TYPE_MAP = {
 }
 
 
+def _normalize_location(location: str) -> str:
+    """Normalize a manifest location to the spelling used for zip entry names.
+
+    COMBINE manifests routinely write archive-root-relative paths as
+    "./file.sedml" (and occasionally "/file.sedml"), while the zip entries are
+    stored as "file.sedml". Zip lookups are exact-string, so the two spellings
+    have to be reconciled before reading.
+    """
+    normalized = location.strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+def _resolve_zip_entry(zf: zipfile.ZipFile, location: str) -> str | None:
+    """Map a manifest location onto an actual entry name in the archive.
+
+    Returns None if no entry can be identified, in which case the caller is
+    responsible for reporting the failure rather than skipping silently.
+    """
+    names = zf.namelist()
+    name_set = set(names)
+
+    normalized = _normalize_location(location)
+    if normalized in name_set:
+        return normalized
+    if location in name_set:
+        return location
+
+    # Last resort: an unambiguous basename match, which covers manifests that
+    # disagree with the archive about directory nesting. Ambiguous matches are
+    # deliberately left unresolved.
+    basename = normalized.rsplit("/", 1)[-1]
+    matches = [name for name in names if name.rsplit("/", 1)[-1] == basename]
+    if len(matches) == 1:
+        return matches[0]
+
+    return None
+
+
 def parse_omex_content(file_content: bytes) -> OmexContent:
     """Parse an OMEX archive and extract model formats and simulation requirements.
 
@@ -62,6 +102,7 @@ def parse_omex_content(file_content: bytes) -> OmexContent:
     model_formats: list[ModelFormat] = []
     simulations: list[SimulationRequirement] = []
     sedml_files: list[str] = []
+    parse_errors: list[str] = []
 
     with zipfile.ZipFile(BytesIO(file_content), 'r') as zf:
         # Parse manifest.xml to find files
@@ -74,28 +115,36 @@ def parse_omex_content(file_content: bytes) -> OmexContent:
             format_uri = content.get("format", "")
 
             # Skip the manifest itself
-            if location == "." or location == "manifest.xml":
+            if _normalize_location(location) in ("", ".", "manifest.xml"):
                 continue
 
             # Check if it's a model file
             if format_uri in MODEL_FORMAT_URIS:
                 model_formats.append(ModelFormat(
                     format_uri=format_uri,
-                    location=location
+                    location=_normalize_location(location)
                 ))
 
             # Check if it's a SED-ML file
             if format_uri in SEDML_FORMAT_URIS:
-                sedml_files.append(location)
+                sedml_files.append(_normalize_location(location))
 
         # Parse each SED-ML file
         for sedml_location in sedml_files:
+            entry_name = _resolve_zip_entry(zf, sedml_location)
+            if entry_name is None:
+                message = f"SED-ML file declared in manifest but not found in archive: {sedml_location}"
+                logger.warning(message)
+                parse_errors.append(message)
+                continue
             try:
-                sedml_content = zf.read(sedml_location)
+                sedml_content = zf.read(entry_name)
                 sedml_simulations = _parse_sedml(sedml_content, model_formats)
                 simulations.extend(sedml_simulations)
             except (KeyError, ET.ParseError) as e:
-                logger.warning(f"Failed to parse SED-ML file {sedml_location}: {e}")
+                message = f"Failed to parse SED-ML file {sedml_location}: {e}"
+                logger.warning(message)
+                parse_errors.append(message)
 
     # Deduplicate simulations by algorithm
     seen_algorithms: set[tuple[str, str]] = set()
@@ -109,7 +158,8 @@ def parse_omex_content(file_content: bytes) -> OmexContent:
     return OmexContent(
         model_formats=model_formats,
         simulations=unique_simulations,
-        sedml_files=sedml_files
+        sedml_files=sedml_files,
+        parse_errors=parse_errors
     )
 
 

--- a/backend/biosim_server/compatibility/router.py
+++ b/backend/biosim_server/compatibility/router.py
@@ -66,6 +66,12 @@ async def check_compatibility(
         raise HTTPException(status_code=400, detail="No SED-ML files found in the OMEX archive")
 
     if not omex_content.simulations:
+        if omex_content.parse_errors:
+            raise HTTPException(
+                status_code=400,
+                detail="No simulations could be read from the SED-ML files: "
+                       + "; ".join(omex_content.parse_errors),
+            )
         raise HTTPException(status_code=400, detail="No simulations found in the SED-ML files")
 
     # Cache the OMEX file to database + GCS so it can be used by /simulations/run

--- a/backend/tests/compatibility/test_omex_parser.py
+++ b/backend/tests/compatibility/test_omex_parser.py
@@ -1,9 +1,12 @@
 """Tests for OMEX archive parsing."""
 
+import io
+import zipfile
+
 import pytest
 from pathlib import Path
 
-from biosim_server.compatibility.omex_parser import parse_omex_content
+from biosim_server.compatibility.omex_parser import _normalize_location, parse_omex_content
 
 
 @pytest.fixture
@@ -78,3 +81,135 @@ def test_parse_invalid_omex() -> None:
     """Test handling of invalid OMEX content."""
     with pytest.raises(Exception):
         parse_omex_content(b"not a valid zip file")
+
+
+SEDML_L1V3 = """<?xml version="1.0" encoding="UTF-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+    <listOfModels>
+        <model id="model1" language="urn:sedml:language:sbml" source="Szymanska2009.xml"/>
+    </listOfModels>
+    <listOfSimulations>
+        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="1000" numberOfPoints="4000">
+            <algorithm kisaoID="KISAO:0000496"/>
+        </uniformTimeCourse>
+    </listOfSimulations>
+</sedML>"""
+
+
+def _build_omex(manifest_locations: dict[str, str], entries: dict[str, str]) -> bytes:
+    """Build an in-memory OMEX archive.
+
+    Args:
+        manifest_locations: manifest `location` -> `format` URI, written verbatim
+            so tests can exercise spellings that differ from the zip entry names.
+        entries: zip entry name -> file contents.
+    """
+    content_elements = "\n".join(
+        f'  <content location="{location}" format="{format_uri}"/>'
+        for location, format_uri in manifest_locations.items()
+    )
+    manifest = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<omexManifest xmlns="http://identifiers.org/combine.specifications/omex-manifest">\n'
+        f"{content_elements}\n"
+        "</omexManifest>"
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.xml", manifest)
+        for name, contents in entries.items():
+            zf.writestr(name, contents)
+    return buf.getvalue()
+
+
+def test_parse_omex_with_dot_slash_manifest_locations() -> None:
+    """Manifest locations written as "./file" must resolve to bare zip entries.
+
+    Regression test: BioModels-derived archives declare "./x.sedml" in the
+    manifest while storing the entry as "x.sedml". Zip lookups are exact-string,
+    so the SED-ML was never read and the endpoint reported that the archive
+    contained no simulations.
+    """
+    file_content = _build_omex(
+        manifest_locations={
+            ".": "http://identifiers.org/combine.specifications/omex",
+            "./Szymanska2009.xml": "http://identifiers.org/combine.specifications/sbml",
+            "./BIOMD0000000896_sim.sedml": "http://identifiers.org/combine.specifications/sed-ml",
+        },
+        entries={
+            "Szymanska2009.xml": "<sbml/>",
+            "BIOMD0000000896_sim.sedml": SEDML_L1V3,
+        },
+    )
+
+    omex_content = parse_omex_content(file_content)
+
+    assert omex_content.parse_errors == []
+    assert omex_content.sedml_files == ["BIOMD0000000896_sim.sedml"]
+    assert [sim.algorithm.id for sim in omex_content.simulations] == ["KISAO:0000496"]
+    assert [sim.simulation_type for sim in omex_content.simulations] == ["uniformTimeCourse"]
+
+    # The "./"-prefixed model location must still match the SED-ML model source
+    assert len(omex_content.model_formats) == 1
+    assert omex_content.model_formats[0].location == "Szymanska2009.xml"
+    assert omex_content.model_formats[0].language == "urn:sedml:language:sbml"
+
+
+def test_parse_omex_with_leading_slash_manifest_locations() -> None:
+    """Locations written as "/file" resolve the same way as "./file"."""
+    file_content = _build_omex(
+        manifest_locations={"/sim.sedml": "http://identifiers.org/combine.specifications/sed-ml"},
+        entries={"sim.sedml": SEDML_L1V3},
+    )
+
+    omex_content = parse_omex_content(file_content)
+
+    assert omex_content.parse_errors == []
+    assert omex_content.sedml_files == ["sim.sedml"]
+    assert len(omex_content.simulations) == 1
+
+
+def test_parse_omex_reports_missing_sedml_instead_of_skipping() -> None:
+    """A declared-but-absent SED-ML file is reported rather than silently ignored."""
+    file_content = _build_omex(
+        manifest_locations={"absent.sedml": "http://identifiers.org/combine.specifications/sed-ml"},
+        entries={},
+    )
+
+    omex_content = parse_omex_content(file_content)
+
+    assert omex_content.simulations == []
+    assert len(omex_content.parse_errors) == 1
+    assert "absent.sedml" in omex_content.parse_errors[0]
+
+
+def test_parse_omex_reports_malformed_sedml() -> None:
+    """Unparseable SED-ML is surfaced as a parse error, not an empty result."""
+    file_content = _build_omex(
+        manifest_locations={"broken.sedml": "http://identifiers.org/combine.specifications/sed-ml"},
+        entries={"broken.sedml": "<sedML><unclosed>"},
+    )
+
+    omex_content = parse_omex_content(file_content)
+
+    assert omex_content.simulations == []
+    assert len(omex_content.parse_errors) == 1
+    assert "broken.sedml" in omex_content.parse_errors[0]
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ("./sim.sedml", "sim.sedml"),
+        ("/sim.sedml", "sim.sedml"),
+        ("sim.sedml", "sim.sedml"),
+        ("./nested/sim.sedml", "nested/sim.sedml"),
+        ("././sim.sedml", "sim.sedml"),
+        ("  ./sim.sedml  ", "sim.sedml"),
+        (".", "."),
+    ],
+)
+def test_normalize_location(location: str, expected: str) -> None:
+    """Manifest location spellings normalize to zip entry names."""
+    assert _normalize_location(location) == expected

--- a/backend/tests/compatibility/test_router.py
+++ b/backend/tests/compatibility/test_router.py
@@ -147,3 +147,95 @@ def test_check_compatibility_success(
     assert "2.2.10" in tellurium["versions"]
     # version_details not populated in default (non-verbose) mode
     assert tellurium["version_details"] is None
+
+
+@patch("biosim_server.compatibility.router.get_biosim_service")
+@patch("biosim_server.compatibility.simulator_matcher._get_simulator_spec")
+def test_check_compatibility_dot_slash_manifest_locations(
+    mock_get_spec: AsyncMock,
+    mock_get_service: AsyncMock,
+    mock_biosim_service: AsyncMock
+) -> None:
+    """An archive whose manifest uses "./" locations must not 400.
+
+    Regression test for BioModels-derived archives (e.g. run
+    61fea4893c41b662ca49b3ca), which declare "./x.sedml" in the manifest while
+    storing the zip entry as "x.sedml". These previously returned 400
+    "No simulations found in the SED-ML files".
+    """
+    mock_get_service.return_value = mock_biosim_service
+    mock_get_spec.return_value = {
+        "id": "tellurium",
+        "name": "tellurium",
+        "version": "2.2.10",
+        "algorithms": [
+            {
+                "kisaoId": {"id": "KISAO_0000496"},
+                "modelFormats": [{"id": "format_2585"}],  # SBML
+                "simulationTypes": [{"id": "SedUniformTimeCourseSimulation"}]
+            }
+        ]
+    }
+
+    import io
+    import zipfile
+
+    sedml = """<?xml version="1.0" encoding="UTF-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+    <listOfModels>
+        <model id="model1" language="urn:sedml:language:sbml" source="Szymanska2009.xml"/>
+    </listOfModels>
+    <listOfSimulations>
+        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="1000" numberOfPoints="4000">
+            <algorithm kisaoID="KISAO:0000496"/>
+        </uniformTimeCourse>
+    </listOfSimulations>
+</sedML>"""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr("manifest.xml", '''<?xml version="1.0" encoding="UTF-8"?>
+<omexManifest xmlns="http://identifiers.org/combine.specifications/omex-manifest">
+  <content location="./Szymanska2009.xml" format="http://identifiers.org/combine.specifications/sbml" master="false"/>
+  <content location="./BIOMD0000000896_sim.sedml" format="http://identifiers.org/combine.specifications/sed-ml" master="true"/>
+  <content location="." format="http://identifiers.org/combine.specifications/omex"/>
+</omexManifest>''')
+        zf.writestr("Szymanska2009.xml", "<sbml/>")
+        zf.writestr("BIOMD0000000896_sim.sedml", sedml)
+
+    client = TestClient(app)
+    response = client.post(
+        "/compatibility/check",
+        files={"uploaded_file": ("test.omex", buf.getvalue(), "application/octet-stream")}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["omex_content"]["sedml_files"] == ["BIOMD0000000896_sim.sedml"]
+    assert data["omex_content"]["parse_errors"] == []
+    assert [s["algorithm"]["id"] for s in data["omex_content"]["simulations"]] == ["KISAO:0000496"]
+    assert "tellurium" in [s["id"] for s in data["eligible_simulators"]]
+
+
+def test_check_compatibility_reports_unreadable_sedml() -> None:
+    """A declared-but-absent SED-ML file yields a specific error, not "no simulations"."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr("manifest.xml", '''<?xml version="1.0" encoding="UTF-8"?>
+<omexManifest xmlns="http://identifiers.org/combine.specifications/omex-manifest">
+  <content location="absent.sedml" format="http://identifiers.org/combine.specifications/sed-ml" master="true"/>
+</omexManifest>''')
+
+    client = TestClient(app)
+    response = client.post(
+        "/compatibility/check",
+        files={"uploaded_file": ("test.omex", buf.getvalue(), "application/octet-stream")}
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "absent.sedml" in detail
+    assert "No simulations could be read" in detail


### PR DESCRIPTION
Fixes #88.

`POST /compatibility/check` returned `400 {"detail":"No simulations found in the SED-ML files"}` for archives that plainly do contain simulations, e.g. run `61fea4893c41b662ca49b3ca`, whose SED-ML holds a `<uniformTimeCourse>` with `kisaoID="KISAO:0000496"`.

## Cause

COMBINE manifests may write archive-root-relative paths as either `file.sedml` or `./file.sedml`. Both are legal, and `./` is common in BioModels-derived archives. The manifest location was passed straight to `zipfile.read()`, which does exact-string lookups, so a `./`-prefixed location raised `KeyError` and the SED-ML was never read. A bare `logger.warning` swallowed that error, leaving `simulations` empty and tripping a guard whose message described an entirely different failure.

The one existing parser fixture uses bare filenames, so this path had never been exercised.

## Changes

- `_normalize_location()` strips leading `./` (repeated) and `/`.
- `_resolve_zip_entry()` maps a manifest location onto a real zip entry: normalized match, then verbatim, then an *unambiguous* basename match. Ambiguous matches are left unresolved rather than guessed.
- Normalized locations are stored in `sedml_files` and `ModelFormat.location`, so reported paths match the real archive paths.
- New `OmexContent.parse_errors` records unresolvable/unparseable SED-ML, and the router reports those specifically. This is what made the bug expensive to diagnose — a read failure was indistinguishable from an archive with genuinely no simulations. The field is additive with a default, so the response schema stays backward compatible.

## Verification

Parsing the reported archive with the fix applied:

```
sedml_files : ['BIOMD0000000896_sim.sedml']
parse_errors: []
simulations : [('KISAO:0000496', 'CVODES', 'uniformTimeCourse')]
model_fmts  : [('Szymanska2009.xml', 'urn:sedml:language:sbml')]
```

The regression test was confirmed to genuinely catch the bug: with the source changes stashed and only the tests applied, `test_check_compatibility_dot_slash_manifest_locations` fails with `assert 400 == 200` — the exact production symptom — and passes with the fix.

7 tests added across `test_omex_parser.py` and `test_router.py`, covering the `./` and `/` spellings, missing and malformed SED-ML, and the parametrized normalizer. A `_build_omex()` helper synthesizes archives in memory, so no new binary fixture is committed.

`ruff check` clean, `mypy --strict` clean across 103 files, `pytest tests/compatibility/` 37 passed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMgPKRM5JVGPFe93kMNvvo
