### PR TITLE
feat: sort eligible_simulators versions newest-first

### DIFF
--- a/backend/biosim_server/compatibility/simulator_matcher.py
+++ b/backend/biosim_server/compatibility/simulator_matcher.py
@@ -1,6 +1,7 @@
 """Match OMEX requirements against simulator capabilities."""
 
 import logging
+import re
 from typing import Any
 
 import aiohttp
@@ -382,6 +383,22 @@ async def _check_version_compatibility(
     return None
 
 
+def _version_sort_key(version: str) -> tuple[tuple[int, ...], int, str]:
+    """Build an ordering key for a simulator version string.
+
+    Components are compared numerically so that "2.2.10" ranks above "2.2.8",
+    and version strings with differing component counts (e.g. vcell's
+    "7.5.0.99") compare element-wise. A pre-release suffix such as
+    "7.5.0.86-dev1" ranks below the corresponding plain release.
+    """
+    release, _, prerelease = version.partition("-")
+    numeric_parts: list[int] = []
+    for part in release.split("."):
+        leading_digits = re.match(r"\d+", part)
+        numeric_parts.append(int(leading_digits.group()) if leading_digits else 0)
+    return (tuple(numeric_parts), 0 if prerelease else 1, prerelease)
+
+
 async def find_compatible_simulators(
     omex_content: OmexContent,
     simulator_versions: list[BiosimulatorVersion],
@@ -446,6 +463,8 @@ async def find_compatible_simulators(
     eligible: list[EligibleSimulator] = []
     for sim_id, details in version_details_by_sim.items():
         any_exact = any(d.exact for d in details)
+        # Newest version first, with version_details kept in the same order
+        details.sort(key=lambda d: _version_sort_key(d.version), reverse=True)
         versions = [d.version for d in details]
         eligible.append(EligibleSimulator(
             id=sim_id,

--- a/backend/tests/compatibility/test_simulator_matcher.py
+++ b/backend/tests/compatibility/test_simulator_matcher.py
@@ -14,6 +14,7 @@ from biosim_server.compatibility.simulator_matcher import (
     _get_algorithm_ancestors,
     _get_equivalence_ancestors,
     _get_simulator_spec,
+    _version_sort_key,
     are_algorithms_equivalent,
     find_compatible_simulators,
     get_kisao_term_name_sync,
@@ -501,3 +502,83 @@ async def test_find_compatible_simulators_real_api() -> None:
     equivalent_matches = [s for s in simulators if not s.exact]
     print(f"\nExact matches ({len(exact_matches)}): {[s.id for s in exact_matches]}")
     print(f"Equivalent matches ({len(equivalent_matches)}): {[s.id for s in equivalent_matches]}")
+
+
+def test_version_sort_key_orders_numerically() -> None:
+    """Version components compare numerically, not lexicographically."""
+    versions = ["2.2.1", "2.2.10", "2.2.8"]
+    assert sorted(versions, key=_version_sort_key, reverse=True) == ["2.2.10", "2.2.8", "2.2.1"]
+
+
+def test_version_sort_key_handles_four_components() -> None:
+    """vcell-style four-component versions sort newest first."""
+    versions = ["7.4.0.68", "7.5.0.99", "7.5.0.108", "7.7.0.9", "7.7.0.10", "7.6.0.40"]
+    assert sorted(versions, key=_version_sort_key, reverse=True) == [
+        "7.7.0.10", "7.7.0.9", "7.6.0.40", "7.5.0.108", "7.5.0.99", "7.4.0.68"
+    ]
+
+
+def test_version_sort_key_ranks_prerelease_below_release() -> None:
+    """A pre-release suffix sorts below the corresponding plain release."""
+    versions = ["7.5.0.86", "7.5.0.86-dev1", "7.5.0.89", "7.5.0.80"]
+    assert sorted(versions, key=_version_sort_key, reverse=True) == [
+        "7.5.0.89", "7.5.0.86", "7.5.0.86-dev1", "7.5.0.80"
+    ]
+
+
+def test_version_sort_key_tolerates_non_numeric_components() -> None:
+    """Unparseable components must not raise; ordering stays total."""
+    versions = ["1.0.0", "latest", "2.0"]
+    ordered = sorted(versions, key=_version_sort_key, reverse=True)
+    assert ordered[0] == "2.0"
+    assert set(ordered) == {"1.0.0", "latest", "2.0"}
+
+
+@pytest.mark.asyncio
+async def test_find_compatible_simulators_returns_versions_descending(
+    sample_omex_content: OmexContent
+) -> None:
+    """eligible_simulators[].versions must list the newest version first."""
+    from unittest.mock import AsyncMock, patch
+
+    # Supplied ascending, as the biosimulators API returns them
+    ascending = ["2.2.1", "2.2.8", "2.2.10"]
+    simulator_versions = [
+        BiosimulatorVersion(
+            id="tellurium",
+            name="tellurium",
+            version=version,
+            image_url=f"ghcr.io/biosimulators/tellurium:{version}",
+            image_digest="sha256:0c22827b4682273810d48ea606ef50c7163e5f5289740951c00c64c669409eae",
+            created="2024-10-10T22:00:50.110Z",
+            updated="2024-10-10T22:00:50.110Z"
+        )
+        for version in ascending
+    ]
+
+    tellurium_spec = {
+        "id": "tellurium",
+        "algorithms": [
+            {
+                "kisaoId": {"id": "KISAO_0000019"},  # CVODE
+                "modelFormats": [{"id": "format_2585"}],  # SBML
+                "simulationTypes": [{"id": "SedUniformTimeCourseSimulation"}]
+            }
+        ]
+    }
+
+    with patch(
+        "biosim_server.compatibility.simulator_matcher._get_simulator_spec",
+        new_callable=AsyncMock
+    ) as mock_get_spec:
+        mock_get_spec.return_value = tellurium_spec
+
+        simulators = await find_compatible_simulators(
+            sample_omex_content, simulator_versions, verbose=True
+        )
+
+    assert len(simulators) == 1
+    assert simulators[0].versions == ["2.2.10", "2.2.8", "2.2.1"]
+    # version_details must stay aligned with the versions array
+    assert simulators[0].version_details is not None
+    assert [d.version for d in simulators[0].version_details] == ["2.2.10", "2.2.8", "2.2.1"]


### PR DESCRIPTION
Closes #89.

Each `eligible_simulators[].versions` array came back in whatever order the biosimulators API returned it, which is ascending, putting the oldest release on top.

## Why a plain sort isn't enough

The live data has three traps:

1. **Lexicographic sorting is wrong** — `"2.2.10" < "2.2.8"` as strings, but `2.2.10` is newer.
2. **Component counts vary** — vcell uses four components (`7.5.0.99`); everything else uses three.
3. **Pre-release suffixes exist** — `7.5.0.86-dev1` must rank below a plain `7.5.0.86` but above `7.5.0.80`.

`_version_sort_key()` handles all three: components compare numerically, differing lengths compare element-wise, and a pre-release ranks below its corresponding release. Non-numeric components degrade to `0` rather than raising, so the ordering stays total for unexpected inputs like `latest`.

`version_details` is sorted and `versions` derived from it, so the two stay index-aligned in `verbose=true` mode.

## Result against real production lists

```
amici     -> ['0.34.2', '0.34.1', '0.34.0', '0.18.1', '0.11.25', ...]
tellurium -> ['2.2.10', '2.2.8', '2.2.1']
vcell     -> ['7.7.0.20', '7.7.0.10', '7.7.0.9', '7.6.0.40', '7.5.0.127',
              '7.5.0.108', '7.5.0.99', '7.5.0.89', '7.5.0.86-dev1', '7.5.0.80', ...]
```

## Reviewer note

This changes the order of an existing API response array. Any client that assumed ascending order — or indexed `versions[0]` expecting the oldest version — will see different results. Worth a glance at the frontend before merge.

5 tests added in `test_simulator_matcher.py` covering each trap plus end-to-end ordering and `version_details` alignment.

`ruff check` clean, `mypy --strict` clean across 103 files, `pytest tests/compatibility/` 29 passed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMgPKRM5JVGPFe93kMNvvo
