### PR TITLE
Fix/minor qol fixes

### DIFF
--- a/frontend/app/app.config.ts
+++ b/frontend/app/app.config.ts
@@ -3,6 +3,12 @@ export default defineAppConfig({
     colors: {
       primary: 'blue',
       neutral: 'slate'
+    },
+    selectMenu: {
+      slots: {
+        viewport: 'lenis-prevent',
+        content: 'w-auto min-w-(--reka-combobox-trigger-width) max-w-[min(400px,calc(100vw-2rem))]'
+      }
     }
   }
 })

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -268,6 +268,7 @@ const navigation_items = ref<NavigationMenuItem[][]>([
 const lenisOptions = {
   // autoRaf: false,
   // lenis options (optional)
+  prevent: (node: any) => !!node.closest('.lenis-prevent')
 }
 
 onMounted(() => {

--- a/frontend/app/components/AppChipList.vue
+++ b/frontend/app/components/AppChipList.vue
@@ -4,6 +4,7 @@ import type {AppChip} from "~/models/common";
 defineProps<{
   chips: AppChip[]
   loading: boolean
+  size: 'sm' | 'xs'
 }>()
 
 const emit = defineEmits<{
@@ -17,6 +18,6 @@ function handle_remove(chip: AppChip) {
 
 <template>
   <div class="w-full flex flex-wrap items-center justify-start gap-2">
-    <Chip v-for="chip in chips" :key="chip.slug" :loading="loading" :label="chip.label" :removable="chip.removable" @removed="handle_remove(chip)"></Chip>
+    <Chip v-for="chip in chips" :key="chip.slug" :loading="loading" :label="chip.label" :removable="chip.removable" :size="size" @removed="handle_remove(chip)"></Chip>
   </div>
 </template>

--- a/frontend/app/components/Chip.vue
+++ b/frontend/app/components/Chip.vue
@@ -16,7 +16,7 @@ function handle_remove($event: Event) {
 </script>
 
 <template>
-  <div class="py-1 rounded-md bg-primary-500/10 border border-primary-500/50 text-primary flex items-center justify-center" :class="{ 'opacity-50 cursor-not-allowed': loading, 'px-2': size === 'sm', 'px-1 py-[2px]': size === 'xs' }">
+  <div class="py-1 rounded-md bg-primary-500/10 border border-primary-500/50 text-primary flex items-center justify-center" :class="{ 'opacity-50 cursor-not-allowed': loading, 'px-2': size === 'sm', 'px-1 py-0.5': size === 'xs' }">
     <UIcon v-if="loading" class="size-4 mr-2 animate-spin" name="i-lucide-loader"></UIcon>
     <p class="text-sm font-medium" :class="{'text-[0.65rem]': size === 'xs', 'text-sm': size === 'sm'}">{{ label }}</p>
     <UTooltip v-if="removable" :text="`Remove ${label}`">

--- a/frontend/app/components/DesignChart.vue
+++ b/frontend/app/components/DesignChart.vue
@@ -1,75 +1,88 @@
 <template>
   <div class="design-chart-container w-full flex flex-col gap-6">
-    <div class="configure-panel border border-neutral-200 rounded-lg p-5 bg-white shadow-sm flex flex-col gap-4">
+    <div class="configure-panel mt-4 border border-neutral-200 rounded-lg p-5 bg-white shadow-sm flex flex-col gap-4">
       <div class="flex items-center justify-between">
         <h3 class="text-lg font-bold">Configure {{ props.visualization.name }}</h3>
+        <UButton color="primary" class="cursor-pointer" label="Generate Plot" :loading="loading" @click="generatePlot" />
       </div>
 
-      <div class="flex flex-col gap-2">
-        <div v-for="(curve, index) in curves" :key="index" class="curve-config flex flex-col md:flex-row items-end gap-4 p-3 bg-neutral-50 border border-neutral-200 rounded relative group">
-
-          <UButton
-            v-if="curves.length > 1"
-            icon="i-lucide-trash"
-            color="error"
-            variant="ghost"
-            size="xs"
-            class="absolute top-1 right-1 md:-right-8 md:top-auto md:bottom-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
-            @click="removeCurve(index)"
-          />
-
-          <UFormField class="w-full md:flex-1" :label="props.visualization._type === 'Histogram1DVisualization' ? `Data ${index + 1}` : `Curve ${index + 1} - X Data`">
-            <USelectMenu
-              v-model="curve.xData"
-              :items="(datasetOptions as any[])"
-              multiple
-              searchable
-              label-key="label"
-              value-key="uri"
-              placeholder="Select data..."
-            />
+      <div class="settings-panel flex flex-col md:flex-row items-end justify-between gap-4">
+        <div class="w-max whitespace-nowrap flex flex-row items-end gap-4">
+          <UFormField label="X-Axis Scale">
+            <USelectMenu class="min-w-35" v-model="xAxisType" :items="['linear', 'log']" />
           </UFormField>
 
-          <UFormField v-if="props.visualization._type !== 'Histogram1DVisualization'" class="w-full md:flex-1" :label="`Curve ${index + 1} - Y Data`">
-            <USelectMenu
-              v-model="curve.yData"
-              :items="(datasetOptions as any[])"
-              multiple
-              searchable
-              label-key="label"
-              value-key="uri"
-              placeholder="Select Y data..."
-            />
+          <UFormField label="Y-Axis Scale">
+            <USelectMenu class="min-w-35" v-model="yAxisType" :items="['linear', 'log']" />
           </UFormField>
         </div>
 
-        <UButton v-if="props.visualization._type !== 'Heatmap2DVisualization'" class="w-max mt-1" icon="i-lucide-plus" color="neutral" variant="outline" size="sm" :label="props.visualization._type === 'Histogram1DVisualization' ? 'Add Data' : 'Add Curve'" @click="addCurve" />
+        <UFormField v-if="props.visualization._type === 'Line2DVisualization'" class="w-max" :ui="{label: 'whitespace-nowrap'}" label="Trace Mode">
+          <USelectMenu class="min-w-35" v-model="traceMode" :items="[{label: 'Lines', value: 'lines'}, {label: 'Markers', value: 'markers'}, {label: 'Lines & Markers', value: 'lines+markers'}]" label-key="label" value-key="value" />
+        </UFormField>
       </div>
 
-      <USeparator class="my-2" />
+      <UCard class="flex-1">
+        <template #header><p><strong>Curve Configuration</strong></p></template>
 
-      <div class="settings-panel flex flex-col md:flex-row items-end gap-4">
-        <UFormField class="w-full md:w-1/4" label="X-Axis Scale">
-          <USelectMenu v-model="xAxisType" :items="['linear', 'log']" />
-        </UFormField>
-
-        <UFormField class="w-full md:w-1/4" label="Y-Axis Scale">
-          <USelectMenu v-model="yAxisType" :items="['linear', 'log']" />
-        </UFormField>
-
-        <UFormField v-if="props.visualization._type === 'Line2DVisualization'" class="w-full md:w-1/4" label="Trace Mode">
-          <USelectMenu v-model="traceMode" :items="[{label: 'Lines', value: 'lines'}, {label: 'Markers', value: 'markers'}, {label: 'Lines & Markers', value: 'lines+markers'}]" label-key="label" value-key="value" />
-        </UFormField>
-
-        <div class="flex-1 flex justify-end">
-          <UButton color="primary" label="Generate Plot" :loading="loading" @click="generatePlot" />
+        <!-- Error Display -->
+        <div v-if="error" class="p-4 mb-4 bg-red-50 text-red-600 rounded">
+          {{ error }}
         </div>
-      </div>
-    </div>
 
-    <!-- Error Display -->
-    <div v-if="error" class="p-4 bg-red-50 text-red-600 rounded">
-      {{ error }}
+        <div v-for="(curve, index) in curves" :key="index" class="curve-config flex flex-col gap-4 p-3 bg-neutral-50/75 border border-neutral-200 rounded relative group" :class="{'mt-2': index > 0}">
+          <div class="flex-1 w-full flex items-center justify-between gap-4">
+            <p><strong>Curve {{index + 1}}</strong></p>
+            <UButton
+              v-if="curves.length > 1"
+              icon="i-lucide-trash"
+              color="error"
+              variant="ghost"
+              size="xs"
+              class="cursor-pointer"
+              @click="removeCurve(index)"
+            />
+          </div>
+          <div class="w-max flex items-center gap-4">
+            <UFormField class="w-full md:flex-1" :label="props.visualization._type === 'Histogram1DVisualization' ? `Data ${index + 1}` : `Curve ${index + 1} - X Data`">
+              <USelectMenu
+                v-model="curve.xData"
+                :items="(datasetOptions as any[])"
+                multiple
+                searchable
+                :content="{
+                      align: 'start',
+                      sideOffset: 4,
+                      collisionPadding: 16
+                    }"
+                label-key="label"
+                value-key="uri"
+                placeholder="Select X Data"
+              />
+            </UFormField>
+            <UFormField v-if="props.visualization._type !== 'Histogram1DVisualization'" class="w-full md:flex-1" :label="`Curve ${index + 1} - Y Data`">
+              <USelectMenu
+                v-model="curve.yData"
+                :items="(datasetOptions as any[])"
+                multiple
+                searchable
+                :content="{
+                      align: 'start',
+                      sideOffset: 4,
+                      collisionPadding: 16
+                    }"
+                label-key="label"
+                value-key="uri"
+                placeholder="Select Y Data"
+              />
+            </UFormField>
+          </div>
+        </div>
+
+        <template #footer>
+          <UButton v-if="props.visualization._type !== 'Heatmap2DVisualization'" class="w-max self-end cursor-pointer" icon="i-lucide-plus" size="sm" :label="props.visualization._type === 'Histogram1DVisualization' ? 'Add Data' : 'Add Curve'" @click="addCurve" />
+        </template>
+      </UCard>
     </div>
 
     <!-- Chart Display -->

--- a/frontend/app/components/SimulationLogs.vue
+++ b/frontend/app/components/SimulationLogs.vue
@@ -21,9 +21,7 @@
           <span class="font-bold">Exception:</span> {{ docLog.exception.message || docLog.exception.type || 'No details provided.' }}
         </div>
 
-        <div v-if="docLog.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner">
-          {{ docLog.output }}
-        </div>
+        <div v-if="docLog.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner" v-dompurify-html="formatLogOutput(docLog.output)"></div>
         <div v-else class="italic text-neutral-500 mt-2">
           No output log available.
         </div>
@@ -46,9 +44,7 @@
         <div v-if="t.task.exception" class="mt-2 text-sm text-red-600">
           <span class="font-bold">Exception:</span> {{ t.task.exception.message || t.task.exception.type || 'No details provided.' }}
         </div>
-        <div v-if="t.task.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner">
-          {{ t.task.output }}
-        </div>
+        <div v-if="t.task.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner" v-dompurify-html="formatLogOutput(t.task.output)"></div>
         <div v-else class="italic text-neutral-500 mt-2">
           No output log available.
         </div>
@@ -71,9 +67,7 @@
         <div v-if="r.report.exception" class="mt-2 text-sm text-red-600">
           <span class="font-bold">Exception:</span> {{ r.report.exception.message || r.report.exception.type || 'No details provided.' }}
         </div>
-        <div v-if="r.report.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner">
-          {{ r.report.output }}
-        </div>
+        <div v-if="r.report.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner" v-dompurify-html="formatLogOutput(r.report.output)"></div>
         <div v-else class="italic text-neutral-500 mt-2">
           No output log available.
         </div>
@@ -96,9 +90,7 @@
         <div v-if="p.plot.exception" class="mt-2 text-sm text-red-600">
           <span class="font-bold">Exception:</span> {{ p.plot.exception.message || p.plot.exception.type || 'No details provided.' }}
         </div>
-        <div v-if="p.plot.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner">
-          {{ p.plot.output }}
-        </div>
+        <div v-if="p.plot.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner" v-dompurify-html="formatLogOutput(p.plot.output)"></div>
         <div v-else class="italic text-neutral-500 mt-2">
           No output log available.
         </div>
@@ -125,9 +117,7 @@
           <span class="font-bold">Exception:</span> {{ logs.exception.message || logs.exception.type || 'No details provided.' }}
         </div>
 
-        <div v-if="logs.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner">
-          {{ logs.output }}
-        </div>
+        <div v-if="logs.output" class="bg-[#1e1e1e] text-[#d4d4d4] p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap font-mono mt-2 leading-relaxed shadow-inner" v-dompurify-html="formatLogOutput(logs.output)"></div>
         <div v-else class="italic text-neutral-500 mt-2">
           No output log available.
         </div>
@@ -139,6 +129,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import Anser from 'anser'
+
+function formatLogOutput(output: string) {
+  if (!output) return '';
+  return Anser.ansiToHtml(output, { use_classes: false });
+}
 
 const props = defineProps<{
   logs: any;

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -300,7 +300,7 @@ function visit_page(e: Event, row: any) {
       </template>
     </UCollapsible>
 
-    <AppChipList :chips="chips" @removed="clear_chip($event)" :loading="loading" v-if="!advanced_filters_open && chips && chips.length"></AppChipList>
+    <AppChipList :chips="chips" @removed="clear_chip($event)" :size="'sm'" :loading="loading" v-if="!advanced_filters_open && chips && chips.length"></AppChipList>
 
 <!--    <Loading v-if="!projects && !error_encountered" message="Fetching simulation projects..."/>-->
 

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -6,7 +6,6 @@ import type {BreadcrumbItem} from "#ui/components/Breadcrumb.vue";
 import {normalize_text} from "~/functions/functions";
 import type {TableFilter, TableFilterConfig, TablePagination} from "~/models/filtering";
 import type {ProjectQueryStat, ProjectQueryStatFilter, ProjectSearchFilter, ProjectStub, ProjectStubPage,} from "~/models/projects";
-import type {CoreRow} from "@tanstack/table-core"
 import type {AppChip} from "~/models/common";
 
 const route = useRoute()
@@ -196,7 +195,7 @@ function change_pagination(new_page: number) {
   fetch_projects()
 }
 
-function update_filter_chips() {
+function _update_filter_chips() {
   if (!searched_filters.value || !searched_filters.value.length) return
 
   chips.value = []

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -257,7 +257,7 @@ function visit_page(e: Event, row: any) {
     </div>
 
     <div class="w-full flex items-center justify-between gap-4">
-      <UInput type="text" class="flex-1" icon="i-heroicons-magnifying-glass" placeholder="Search projects" v-model="fuzzy_search_term" />
+      <UInput type="text" class="flex-1" icon="i-heroicons-magnifying-glass" @keydown.enter="fetch_projects()" placeholder="Search projects" v-model="fuzzy_search_term" />
 
       <UButton
         label="Advanced Filters"
@@ -291,8 +291,13 @@ function visit_page(e: Event, row: any) {
                 :items="filter.values"
                 :loading="loading"
                 :multiple="true"
-                v-model="searched_filters[filter._index]!.allowable_values"
-                @update:model-value="update_filter_chips()"
+                :content="{
+                  align: 'start',
+                  sideOffset: 4,
+                  collisionPadding: 16
+                }"
+                :model-value="get_allowable_values(filter.target)"
+                @update:model-value="set_allowable_values(filter.target, $event)"
               />
             </div>
           </template>

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -196,7 +196,7 @@ function get_allowable_values(target: string): string[] {
 }
 
 function set_allowable_values(target: string, values: string[]) {
-  let filter = searched_filters.value.find(f => f.target === target)
+  const filter = searched_filters.value.find(f => f.target === target)
   if (filter) {
     filter.allowable_values = values
   } else {

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {ref, resolveComponent, useTemplateRef} from 'vue'
+import {ref, useTemplateRef} from 'vue'
 import {upperFirst} from 'scule'
 import type {TableColumn} from '@nuxt/ui'
 import type {BreadcrumbItem} from "#ui/components/Breadcrumb.vue";
@@ -8,9 +8,6 @@ import type {TableFilter, TableFilterConfig, TablePagination} from "~/models/fil
 import type {ProjectQueryStat, ProjectQueryStatFilter, ProjectSearchFilter, ProjectStub, ProjectStubPage,} from "~/models/projects";
 import type {CoreRow} from "@tanstack/table-core"
 import type {AppChip} from "~/models/common";
-
-const UButton = resolveComponent('UButton')
-const UDropdownMenu = resolveComponent('UDropdownMenu')
 
 const route = useRoute()
 const display_mode = ref<'cards' | 'table'>('cards')
@@ -23,53 +20,36 @@ const chips = ref<AppChip[]>([])
 const columns: TableColumn<ProjectStub>[] = [
   {
     accessorKey: 'id',
-    header: 'Id',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => `${row.getValue('id')}`
+    header: 'Id'
   },
-  /*{
-    accessorKey: 'simulationRun',
-    header: 'Simulation Run',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => `#${row.getValue('simulationRun')}`
-  },*/
   {
     accessorKey: 'name',
-    header: 'Name',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => `${row.getValue('name')}`
+    header: 'Name'
   },
   {
     accessorKey: 'summary',
-    header: 'Abstract Summary',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => `${row.getValue('summary')}`
+    header: 'Abstract Summary'
   },
   {
     accessorKey: 'created',
-    header: 'Created',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => {
-      return new Date(row.getValue('created')).toLocaleString('en-US', {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true
-      })
-    }
+    header: 'Created'
   },
   {
     accessorKey: 'updated',
-    header: 'Updated',
-    cell: ({ row }: { row: CoreRow<ProjectStub> }) => {
-      return new Date(row.getValue('updated')).toLocaleString('en-US', {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true
-      })
-    }
+    header: 'Updated'
   }
 ]
+
+function formatDate(dateString: string) {
+  return new Date(dateString).toLocaleString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  })
+}
 
 const table = useTemplateRef('table')
 const loading = ref(true)
@@ -357,6 +337,15 @@ function visit_page(e: Event, row: any) {
         :columns="columns"
         @select="visit_page"
         sticky>
+        <template #id-cell="{ row }">
+          <NuxtLink :to="`/projects/${row.original.id}`" class="text-primary-500 hover:underline" @click.stop>{{ row.original.id }}</NuxtLink>
+        </template>
+        <template #created-cell="{ row }">
+          {{ formatDate(row.original.created) }}
+        </template>
+        <template #updated-cell="{ row }">
+          {{ formatDate(row.original.updated) }}
+        </template>
       </UTable>
 
       <div class="card_wrapper w-full gap-4" v-if="display_mode == 'cards'">

--- a/frontend/app/pages/biosim-db.vue
+++ b/frontend/app/pages/biosim-db.vue
@@ -143,7 +143,11 @@ async function fetch_projects() {
       }
     }).then((query_stats: ProjectQueryStat[]) => {
       filter_suggestions.value = query_stats_to_filter_groups(query_stats)
-      searched_filters.value = filter_suggestions.value.map((f, _index) => ({ target: f.target, allowable_values: []}))
+      const old_searched = searched_filters.value
+      searched_filters.value = filter_suggestions.value.map((f, _index) => {
+        const existing = old_searched.find(s => s.target === f.target)
+        return { target: f.target, allowable_values: existing ? existing.allowable_values : [] }
+      })
     })
 
     return
@@ -184,6 +188,21 @@ function clear_chip(chip: AppChip) {
   chips.value.splice(chips.value.indexOf(chip), 1)
 
   fetch_projects()
+}
+
+function get_allowable_values(target: string): string[] {
+  const filter = searched_filters.value.find(f => f.target === target)
+  return filter ? filter.allowable_values : []
+}
+
+function set_allowable_values(target: string, values: string[]) {
+  let filter = searched_filters.value.find(f => f.target === target)
+  if (filter) {
+    filter.allowable_values = values
+  } else {
+    searched_filters.value.push({ target, allowable_values: values })
+  }
+  _update_filter_chips()
 }
 
 function on_column_toggle() {
@@ -322,8 +341,8 @@ function visit_page(e: Event, row: any) {
           </UDropdownMenu>
 
           <div class="w-max flex items-center justify-end rounded bg-neutral-100">
-            <UButton size="sm" :label="`${display_mode == 'cards' ? '' : 'Table'}`" class="cursor-pointer" :color="`${display_mode == 'cards' ? 'subtle' : 'primary'}`" icon="i-lucide-list" type="button" @click="display_mode = 'table'"></UButton>
-            <UButton size="sm" :label="`${display_mode == 'table' ? '' : 'Cards'}`" class="cursor-pointer" :color="`${display_mode == 'table' ? 'subtle' : 'primary'}`" icon="i-lucide-layout-grid" type="button" @click="display_mode = 'cards'"></UButton>
+            <UButton size="sm" :label="`${display_mode == 'cards' ? '' : 'Table'}`" class="cursor-pointer" :color="`${display_mode == 'cards' ? 'neutral' : 'primary'}`" :variant="`${display_mode == 'cards' ? 'ghost' : 'solid'}`" icon="i-lucide-list" type="button" @click="display_mode = 'table'"></UButton>
+            <UButton size="sm" :label="`${display_mode == 'table' ? '' : 'Cards'}`" class="cursor-pointer" :color="`${display_mode == 'table' ? 'neutral' : 'primary'}`" :variant="`${display_mode == 'table' ? 'ghost' : 'solid'}`" icon="i-lucide-layout-grid" type="button" @click="display_mode = 'cards'"></UButton>
           </div>
         </div>
       </div>

--- a/frontend/app/pages/projects/[id].vue
+++ b/frontend/app/pages/projects/[id].vue
@@ -64,6 +64,15 @@ const plot_config = ref({
 
 const run_specifications = ref<SimulationRunSedDocument | undefined>(undefined)
 
+const isDescriptionExpanded = ref(false)
+const descriptionContent = computed(() => {
+  const raw = run_summary.value?.metadata?.[0]?.description;
+  if (!raw) return { html: '', isLong: false };
+  const stripped = raw.replace(/<\/?[^>]+(>|$)/g, "");
+  
+  return { html: raw, isLong: stripped.length >= 250 };
+})
+
 useSeoMeta({
   title: () => project_summary.value ? project_summary.value.simulationRun.name : 'Project',
   description: () => project_summary.value?.simulationRun?.metadata?.[0]?.abstract || 'Explore this project on BioSimulations.',
@@ -203,7 +212,12 @@ const detailedInfoSections = computed(() => getMetadataSections())
 
         <div class="page_header relative overflow-hidden w-full p-8 bg-primary-500 text-white flex flex-col items-center justify-center gap-2 rounded-lg">
           <h1 class="text-xl font-bold">{{normalize_text(run_summary!.name)}}</h1>
-          <p class="text-center" v-dompurify-html="run_summary?.metadata?.[0]?.description"></p>
+          <template v-if="descriptionContent.html">
+            <div class="text-center" :class="{'line-clamp-3': descriptionContent.isLong && !isDescriptionExpanded}" v-dompurify-html="descriptionContent.html"></div>
+            <UButton v-if="descriptionContent.isLong" @click="isDescriptionExpanded = !isDescriptionExpanded" class="mt-2 bg-white text-primary-500 font-bold hover:bg-gray-100 transition-colors" size="sm">
+              {{ isDescriptionExpanded ? 'Show Less' : 'Show More' }}
+            </UButton>
+          </template>
         </div>
 
         <div class="w-full flex flex-col gap-4">

--- a/frontend/app/pages/projects/[id].vue
+++ b/frontend/app/pages/projects/[id].vue
@@ -69,7 +69,6 @@ const descriptionContent = computed(() => {
   const raw = run_summary.value?.metadata?.[0]?.description;
   if (!raw) return { html: '', isLong: false };
   const stripped = raw.replace(/<\/?[^>]+(>|$)/g, "");
-  
   return { html: raw, isLong: stripped.length >= 250 };
 })
 

--- a/frontend/app/pages/projects/[id].vue
+++ b/frontend/app/pages/projects/[id].vue
@@ -221,6 +221,7 @@ const detailedInfoSections = computed(() => getMetadataSections())
                 </div>
                 <NuxtImg :src="`${runtimeConfig.public.legacy_api_url}/files/${run_summary!.id}/${run_summary!.metadata![0]!.thumbnails[0]}/download?thumbnail=view`" alt="Simulation Thumbnail Image" class="w-full" />
                 <vue-easy-lightbox
+                  class="lenis-prevent"
                   :visible="img_zoomed"
                   :imgs="[`${runtimeConfig.public.legacy_api_url}/files/${run_summary!.id}/${run_summary!.metadata![0]!.thumbnails[0]}/download`]"
                   :index="0"

--- a/frontend/app/pages/runs/[id].vue
+++ b/frontend/app/pages/runs/[id].vue
@@ -84,7 +84,6 @@ const descriptionContent = computed(() => {
   const raw = run_summary.value?.metadata?.[0]?.description;
   if (!raw) return { html: '<p><em>No description available for this run.</em></p>', isLong: false };
   const stripped = raw.replace(/<\/?[^>]+(>|$)/g, "");
-  
   return { html: raw, isLong: stripped.length >= 250 };
 })
 

--- a/frontend/app/pages/runs/[id].vue
+++ b/frontend/app/pages/runs/[id].vue
@@ -79,6 +79,15 @@ const plot_config = ref({
 const run_specifications = ref<SimulationRunSedDocument | undefined>(undefined)
 const run_logs = ref<any>()
 
+const isDescriptionExpanded = ref(false)
+const descriptionContent = computed(() => {
+  const raw = run_summary.value?.metadata?.[0]?.description;
+  if (!raw) return { html: '<p><em>No description available for this run.</em></p>', isLong: false };
+  const stripped = raw.replace(/<\/?[^>]+(>|$)/g, "");
+  
+  return { html: raw, isLong: stripped.length >= 250 };
+})
+
 function downloadStructuredLog() {
   if (!run_logs.value) return;
   const logStr = JSON.stringify(run_logs.value, null, 2);
@@ -209,7 +218,10 @@ onMounted(async () => {
 
         <div class="page_header relative overflow-hidden w-full p-8 bg-primary-500 text-white flex flex-col items-center justify-center gap-2 rounded-lg">
           <h1 class="text-xl font-bold">{{normalize_text(run_info!.name)}}</h1>
-          <p class="text-center" v-dompurify-html="run_summary?.metadata?.[0]?.description ? run_summary?.metadata?.[0]?.description : '<p><em>No description available for this run.</em></p>'"></p>
+          <div class="text-center" :class="{'line-clamp-3': descriptionContent.isLong && !isDescriptionExpanded}" v-dompurify-html="descriptionContent.html"></div>
+          <UButton v-if="descriptionContent.isLong" @click="isDescriptionExpanded = !isDescriptionExpanded" class="mt-2 bg-white text-primary-500 font-bold hover:bg-gray-100 transition-colors" size="sm">
+            {{ isDescriptionExpanded ? 'Show Less' : 'Show More' }}
+          </UButton>
         </div>
 
         <div class="w-full flex flex-col gap-4">

--- a/frontend/app/pages/runs/[id].vue
+++ b/frontend/app/pages/runs/[id].vue
@@ -227,6 +227,7 @@ onMounted(async () => {
                 </div>
                 <NuxtImg :src="`${runtimeConfig.public.legacy_api_url}/files/${run_info!.id}/${run_summary!.metadata![0]!.thumbnails[0]}/download?thumbnail=view`" alt="Simulation Thumbnail Image" class="w-full" />
                 <vue-easy-lightbox
+                  class="lenis-prevent"
                   :visible="img_zoomed"
                   :imgs="[`${runtimeConfig.public.legacy_api_url}/files/${run_info!.id}/${run_summary!.metadata![0]!.thumbnails[0]}/download`]"
                   :index="0"

--- a/frontend/app/pages/simulations/index.vue
+++ b/frontend/app/pages/simulations/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { h, resolveComponent, ref, useTemplateRef } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 import { upperFirst } from 'scule'
 import type {TableColumn} from '@nuxt/ui'
 import { useClipboard } from '@vueuse/core'
@@ -9,10 +9,6 @@ import type {TableFilterConfig, TableSort, TablePagination} from "~/models/filte
 import type {BreadcrumbItem} from "#ui/components/Breadcrumb.vue";
 import {normalize_text} from "~/functions/functions";
 import type {CoreRow} from "@tanstack/table-core";
-
-const UButton = resolveComponent('UButton')
-const UBadge = resolveComponent('UBadge')
-const UDropdownMenu = resolveComponent('UDropdownMenu')
 
 const toast = useToast()
 const { copy } = useClipboard()
@@ -38,156 +34,124 @@ onMounted(async () => {
 const columns: (TableColumn<SimulationRun> & { accessorKey?: string })[] = [
   {
     accessorKey: 'biosimulationsRunId',
-    header: 'Identifier',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => row.getValue('biosimulationsRunId')
+    header: 'Identifier'
   },
   {
     accessorKey: 'name',
-    header: 'Name',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => row.getValue('name')
+    header: 'Name'
   },
   {
     accessorKey: 'status',
-    header: 'Status',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => {
-      const color = ({
-        SUCCEEDED: 'success' as const,
-        FAILED: 'error' as const,
-        CREATED: 'info' as const
-      })[row.getValue('status') as string]
-
-      return h(UBadge, { class: 'capitalize', variant: 'subtle', color }, () => row.getValue('status'))
-    }
+    header: 'Status'
   },
   {
     accessorKey: 'simulator',
-    header: 'Simulator',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => row.getValue('simulator')
+    header: 'Simulator'
   },
   {
     accessorKey: 'submitted',
-    header: 'Submitted',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => {
-      return new Date(row.getValue('submitted')).toLocaleString('en-US', {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true
-      })
-    }
+    header: 'Submitted'
   },
   {
     id: 'actions',
+    accessorKey: undefined,
     enableHiding: false,
     meta: {
       class: {
         td: 'text-right'
       }
-    },
-    cell: ({ row }) => {
-      const items = [
-        {
-          type: 'label',
-          label: 'Actions'
-        },
-        {
-          label: 'Copy Sharable Link',
-          icon: 'i-lucide-copy',
-          onSelect() {
-            copy(`${runtimeConfig.public.base_url}/runs/${row.original.biosimulationsRunId}`)
-
-            toast.add({
-              title: 'Link copied to clipboard!',
-              color: 'success',
-              icon: 'i-lucide-circle-check'
-            })
-          }
-        },
-        {
-          label: 'Export Run',
-          icon: 'i-lucide-download',
-          onSelect() {
-            window.open(`${runtimeConfig.public.legacy_api_url}/runs/${row.original.biosimulationsRunId}/download`, '_blank')
-          }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'View Visualization',
-          icon: 'i-lucide-chart-bar',
-          onSelect() {
-            navigateTo(`/runs/${row.original.biosimulationsRunId}#visualization`)
-          }
-        },
-        {
-          label: 'View Logs',
-          icon: 'i-lucide-file-text',
-          onSelect() {
-            navigateTo(`/runs/${row.original.biosimulationsRunId}#logs`)
-          }
-        },
-        {
-          label: 'Rerun Simulation',
-          icon: 'i-lucide-rotate-ccw',
-          onSelect() {
-            // Add corresponding function here
-          }
-        },
-        {
-          label: 'Publish Simulation',
-          icon: 'i-lucide-megaphone',
-          onSelect() {
-            // Add corresponding function here
-          }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Delete Run',
-          icon: 'i-lucide-trash',
-          onSelect(_e: any) {
-            deleting_row_id.value = row.original.biosimulationsRunId
-          }
-        }
-      ]
-
-      return h('div', { class: 'flex items-center justify-end' }, [
-        h(resolveComponent('UPopover'), {
-          open: deleting_row_id.value === row.original.biosimulationsRunId,
-          'onUpdate:open': (val: boolean) => {
-            if (!val && deleting_row_id.value === row.original.biosimulationsRunId) {
-              deleting_row_id.value = null
-            }
-          },
-          content: { align: 'end' }
-        }, {
-          default: () => h(resolveComponent('UDropdownMenu'), {
-            'content': {
-              align: 'end'
-            },
-            items,
-            'aria-label': 'Actions dropdown'
-          }, () => h(resolveComponent('UButton'), {
-            'icon': 'i-lucide-ellipsis-vertical',
-            'color': 'neutral',
-            'variant': 'ghost',
-            'aria-label': 'Actions dropdown'
-          })),
-          content: () => h('div', { class: 'p-4 flex flex-col gap-2 w-64 text-left' }, [
-            h('p', { class: 'text-sm font-normal text-color' }, ['Are you sure you want to delete ', h('strong', row.original.name || row.original.id), '?']),
-            h('div', { class: 'flex justify-end gap-2 mt-2' }, [
-              h(resolveComponent('UButton'), { label: 'Cancel', color: 'neutral', variant: 'ghost', size: 'xs', onClick: () => deleting_row_id.value = null }),
-              h(resolveComponent('UButton'), { label: 'Delete', color: 'error', variant: 'solid', size: 'xs', onClick: () => confirm_delete(row.original as SimulationRun) })
-            ])
-          ])
-        })
-      ])
     }
-  }]
+  }
+]
+
+function getActionItems(row: CoreRow<SimulationRun>) {
+  return [
+    {
+      type: 'label',
+      label: 'Actions'
+    },
+    {
+      label: 'Copy Sharable Link',
+      icon: 'i-lucide-copy',
+      onSelect() {
+        copy(`${runtimeConfig.public.base_url}/runs/${row.original.biosimulationsRunId}`)
+
+        toast.add({
+          title: 'Link copied to clipboard!',
+          color: 'success',
+          icon: 'i-lucide-circle-check'
+        })
+      }
+    },
+    {
+      label: 'Export Run',
+      icon: 'i-lucide-download',
+      onSelect() {
+        window.open(`${runtimeConfig.public.legacy_api_url}/runs/${row.original.biosimulationsRunId}/download`, '_blank')
+      }
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'View Visualization',
+      icon: 'i-lucide-chart-bar',
+      onSelect() {
+        navigateTo(`/runs/${row.original.biosimulationsRunId}#visualization`)
+      }
+    },
+    {
+      label: 'View Logs',
+      icon: 'i-lucide-file-text',
+      onSelect() {
+        navigateTo(`/runs/${row.original.biosimulationsRunId}#logs`)
+      }
+    },
+    {
+      label: 'Rerun Simulation',
+      icon: 'i-lucide-rotate-ccw',
+      onSelect() {
+        // Add corresponding function here
+      }
+    },
+    {
+      label: 'Publish Simulation',
+      icon: 'i-lucide-megaphone',
+      onSelect() {
+        // Add corresponding function here
+      }
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Delete Run',
+      icon: 'i-lucide-trash',
+      onSelect(_e: any) {
+        deleting_row_id.value = row.original.biosimulationsRunId
+      }
+    }
+  ]
+}
+
+function formatDate(dateString: string) {
+  return new Date(dateString).toLocaleString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  })
+}
+
+function getStatusColor(status: string) {
+  return ({
+    SUCCEEDED: 'success' as const,
+    FAILED: 'error' as const,
+    CREATED: 'info' as const
+  })[status] || 'neutral'
+}
 
 const headerColumns = computed(() =>
   columns.filter((c): c is typeof c & { accessorKey: string } => typeof c.accessorKey === 'string')
@@ -455,7 +419,7 @@ async function confirm_delete(run: SimulationRun) {
               variant="ghost"
               :label="tableColumn.columnDef.header"
               :icon="table_sort.id === column.accessorKey ? (table_sort.direction === 'asc' ? 'i-lucide-arrow-up' : 'i-lucide-arrow-down') : 'i-lucide-arrow-up-down'"
-              class="-mx-2.5"
+              class="-mx-2.5 cursor-pointer"
               @click="change_sort(column.accessorKey)"
             />
 
@@ -463,6 +427,7 @@ async function confirm_delete(run: SimulationRun) {
               <UButton
                 :color="table_filters.filters[column.accessorKey]!.value ? 'primary' : 'neutral'"
                 variant="ghost"
+                class="cursor-pointer"
                 icon="i-lucide-filter"
               />
               <template #content>
@@ -545,9 +510,44 @@ async function confirm_delete(run: SimulationRun) {
             </UPopover>
           </div>
         </template>
-<!--        <template #name-cell="{ row }">
-          <p @click="process_click(row)">{{row}}</p>
-        </template>-->
+        <template #biosimulationsRunId-cell="{ row }">
+          <NuxtLink
+            :to="`/runs/${row.getValue('biosimulationsRunId')}`"
+            class="font-medium text-primary hover:underline"
+          >
+            {{ row.getValue('biosimulationsRunId') }}
+          </NuxtLink>
+        </template>
+        <template #status-cell="{ row }">
+          <UBadge class="capitalize" variant="subtle" :color="getStatusColor(row.original.status)">{{ row.original.status }}</UBadge>
+        </template>
+        <template #submitted-cell="{ row }">
+          {{ formatDate(row.original.submitted) }}
+        </template>
+        <template #actions-cell="{ row }">
+          <div class="flex items-center justify-end">
+            <UPopover :open="deleting_row_id === row.original.biosimulationsRunId"
+                      @update:open="(val: boolean) => { if (!val && deleting_row_id === row.original.biosimulationsRunId) deleting_row_id = null }"
+                      :content="{ align: 'end' }">
+              <template #default>
+                <UDropdownMenu :content="{ align: 'end' }" :items="getActionItems(row)" aria-label="Actions dropdown">
+                  <UButton class="cursor-pointer" icon="i-lucide-ellipsis-vertical" color="neutral" variant="ghost" aria-label="Actions dropdown" />
+                </UDropdownMenu>
+              </template>
+              <template #content>
+                <div class="p-4 flex flex-col gap-2 w-64 text-left">
+                  <p class="text-sm font-normal text-color">
+                    Are you sure you want to delete <strong>{{ row.original.name || row.original.id }}</strong>?
+                  </p>
+                  <div class="flex justify-end gap-2 mt-2">
+                    <UButton label="Cancel" color="neutral" variant="ghost" size="xs" @click="deleting_row_id = null" />
+                    <UButton label="Delete" color="error" variant="solid" size="xs" @click="confirm_delete(row.original)" />
+                  </div>
+                </div>
+              </template>
+            </UPopover>
+          </div>
+        </template>
       </UTable>
 
       <USeparator class="mb-4"></USeparator>

--- a/frontend/app/pages/simulations/index.vue
+++ b/frontend/app/pages/simulations/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, useTemplateRef } from 'vue'
 import { upperFirst } from 'scule'
-import type {TableColumn} from '@nuxt/ui'
+import type {DropdownMenuItem, TableColumn} from '@nuxt/ui'
 import { useClipboard } from '@vueuse/core'
 import type {SimulationRuns, SimulationRun} from "~/models/simulators";
 import Loading from "~/components/Loading.vue";
@@ -64,7 +64,7 @@ const columns: (TableColumn<SimulationRun> & { accessorKey?: string })[] = [
   }
 ]
 
-function getActionItems(row: CoreRow<SimulationRun>) {
+function getActionItems(row: CoreRow<SimulationRun>): DropdownMenuItem[] {
   return [
     {
       type: 'label',
@@ -417,7 +417,7 @@ async function confirm_delete(run: SimulationRun) {
             <UButton
               color="neutral"
               variant="ghost"
-              :label="tableColumn.columnDef.header"
+              label="{{ tableColumn.columnDef.header }}"
               :icon="table_sort.id === column.accessorKey ? (table_sort.direction === 'asc' ? 'i-lucide-arrow-up' : 'i-lucide-arrow-down') : 'i-lucide-arrow-up-down'"
               class="-mx-2.5 cursor-pointer"
               @click="change_sort(column.accessorKey)"

--- a/frontend/app/pages/simulations/index.vue
+++ b/frontend/app/pages/simulations/index.vue
@@ -37,9 +37,9 @@ onMounted(async () => {
 
 const columns: (TableColumn<SimulationRun> & { accessorKey?: string })[] = [
   {
-    accessorKey: 'id',
-    header: 'Id',
-    cell: ({ row }: { row: CoreRow<SimulationRun> }) => row.getValue('id')
+    accessorKey: 'biosimulationsRunId',
+    header: 'Identifier',
+    cell: ({ row }: { row: CoreRow<SimulationRun> }) => row.getValue('biosimulationsRunId')
   },
   {
     accessorKey: 'name',
@@ -150,16 +150,16 @@ const columns: (TableColumn<SimulationRun> & { accessorKey?: string })[] = [
           label: 'Delete Run',
           icon: 'i-lucide-trash',
           onSelect(_e: any) {
-            deleting_row_id.value = row.original.id
+            deleting_row_id.value = row.original.biosimulationsRunId
           }
         }
       ]
 
       return h('div', { class: 'flex items-center justify-end' }, [
         h(resolveComponent('UPopover'), {
-          open: deleting_row_id.value === row.original.id,
+          open: deleting_row_id.value === row.original.biosimulationsRunId,
           'onUpdate:open': (val: boolean) => {
-            if (!val && deleting_row_id.value === row.original.id) {
+            if (!val && deleting_row_id.value === row.original.biosimulationsRunId) {
               deleting_row_id.value = null
             }
           },

--- a/frontend/app/pages/simulations/run.vue
+++ b/frontend/app/pages/simulations/run.vue
@@ -6,6 +6,7 @@
   import {normalize_text} from "~/functions/functions";
   import {type ArchiveCompatibilityResponse, type ConglomerateStatus, RunSimulationPayload, type Simulator, type SimulatorSelection} from "~/models/simulators";
   import { z } from 'zod'
+  import { randomName } from '@scaleway/random-name'
   //</editor-fold>
 
   const config = useRuntimeConfig()
@@ -58,6 +59,7 @@
 
   const archive_processed = ref(false)
   const submission_payload = reactive(new RunSimulationPayload())
+  submission_payload.name = randomName()
 
   const archive_compatibility_response = ref<ArchiveCompatibilityResponse | null>(null)
   const eligible_simulators = ref<Simulator[]>([])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@nuxt/image": "^2.0.0",
         "@nuxt/ui": "^4.2.1",
         "@nuxtjs/seo": "^5.3.6",
+        "@scaleway/random-name": "^6.0.2",
         "@stdlib/array-shape": "^0.2.3",
         "@stdlib/array-to-iterator": "^0.2.3",
         "@stdlib/iter-last": "^0.2.3",
@@ -6521,6 +6522,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scaleway/random-name": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@scaleway/random-name/-/random-name-6.0.2.tgz",
+      "integrity": "sha512-fhR2aCzxoZlOZcCM42srbALdpdqMy79LwOK5mVf4sGG1uknn095mr5PQ/0/zwfk/FX2KycZwbKJzr4zP6CG3Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24.x"
+      }
     },
     "node_modules/@simple-git/args-pathspec": {
       "version": "1.0.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@stdlib/ndarray-base-to-array": "^0.2.2",
         "@stdlib/ndarray-ind2sub": "^0.2.3",
         "@stdlib/stats-iter-prod": "^0.2.3",
+        "anser": "^2.3.5",
         "dotenv": "^17.4.2",
         "hex-to-rgba": "^2.0.1",
         "lenis": "^1.3.17",
@@ -20316,6 +20317,12 @@
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
       "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
       "license": "MIT"
     },
     "node_modules/ansi-regex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.2.1",
     "@nuxtjs/seo": "^5.3.6",
+    "@scaleway/random-name": "^6.0.2",
     "@stdlib/array-shape": "^0.2.3",
     "@stdlib/array-to-iterator": "^0.2.3",
     "@stdlib/iter-last": "^0.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@stdlib/ndarray-base-to-array": "^0.2.2",
     "@stdlib/ndarray-ind2sub": "^0.2.3",
     "@stdlib/stats-iter-prod": "^0.2.3",
+    "anser": "^2.3.5",
     "dotenv": "^17.4.2",
     "hex-to-rgba": "^2.0.1",
     "lenis": "^1.3.17",


### PR DESCRIPTION
@jcschaff

#### **A series of QOL improvements:**
1. Declarative Table Columns (biosim-db.vue, simulations/index.vue): Refactored the data tables to move away from constructing DOM objects via h() functions in the script. Cell rendering logic (such as date formatting and row links) has been migrated into the Vue template via slots, improving maintainability and aligning with standard Nuxt UI design patterns
2. Project Linking (biosim-db.vue): The Id column in the database table is now an interactive NuxtLink, allowing users to navigate directly to the projects/[id] details page seamlessly.
3. Smart Description Truncation (projects/[id].vue, runs/[id].vue): Implemented a "Show More / Show Less" UI toggle for the blue header descriptions on detail pages. The toggle safely handles HTML content, utilizing CSS line-clamp for clean visual truncation without breaking inner HTML tags when descriptions exceed 250 characters.
4. Restored Log Syntax Highlighting (SimulationLogs.vue): Integrated the anser package to parse raw ANSI escape sequences embedded in the API's backend logs. Simulation task, report, and plot logs now render with full terminal color syntax highlighting.
5. Pre-filled Simulation Names (simulations/run.vue): Integrated @scaleway/random-name to automatically populate the simulation name field (e.g., focused-hopper) on the "Run a Simulation" page, expediting the workflow and removing naming burdens for users who just want to quickly launch a run.
6. Fixed Advanced Filtering (biosim-db.vue): Re-implemented the missing get_allowable_values and set_allowable_values handlers, restoring the ability to apply dynamic facet filters. Additionally, patched a state bug where updating the search query would unintentionally wipe out active user filter selections.