### PR TITLE
Add Keycloak-backed tests for email-claim precedence and fallback

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,3 +74,9 @@ python_files = "main.py"
 # Non-package project: put the backend root on sys.path so `biosim_server`
 # and `tests` import without an editable install (poetry used to install both).
 pythonpath = ["."]
+
+[tool.basedpyright]
+pythonVersion = "3.13"
+venvPath = "."
+venv = ".venv"
+extraPaths = ["."]

--- a/backend/tests/common/test_auth0.py
+++ b/backend/tests/common/test_auth0.py
@@ -1,0 +1,55 @@
+"""Integration tests for get_current_user's email-claim parsing against a real
+Keycloak dev container -- no mocked JWKS/jwt.decode, no mocked payload. These
+exercise the actual JWT-verification path in common/auth/auth0.py (JWKS fetch,
+RS256 signature check, issuer/audience check) via real tokens issued by three
+purpose-built clients in the test realm (tests/fixtures/keycloak/realm.json):
+
+- "biosim-test-client": stamps a plain "email" claim only -- the fallback path.
+- "biosim-test-client-namespaced-email": stamps both a hardcoded namespaced
+  "https://api.biosimulations.org/email" claim and a plain "email" claim, to
+  prove the namespaced claim wins (mirrors real Auth0 tokens, where a
+  Post-Login Action stamps the namespaced claim).
+- "biosim-test-client-no-email": stamps neither claim, to prove a missing
+  email degrades to None rather than crashing.
+
+End-to-end RBAC coverage (roles, endpoint access) lives separately in
+tests/rbac_demo/test_keycloak_integration.py; this file is scoped to the
+email-claim precedence/fallback logic in get_current_user.
+"""
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+from biosim_server.common.auth.auth0 import get_current_user
+
+pytestmark = pytest.mark.integration_local
+
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_reads_namespaced_email_claim(alice_token_namespaced_email: str) -> None:
+    """A real token carrying both the namespaced claim and a plain "email" claim
+    -- the namespaced claim must be preferred."""
+    user = await get_current_user(_creds(alice_token_namespaced_email))
+    assert user.email == "real@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_falls_back_to_plain_email_claim(alice_token: str) -> None:
+    """A real token with only a plain "email" claim (e.g. the Keycloak realm's
+    default client, same shape used by tests/rbac_demo/test_keycloak_integration.py)
+    keeps working via the fallback."""
+    user = await get_current_user(_creds(alice_token))
+    assert user.email == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_no_email_claim_at_all(alice_token_no_email_claim: str) -> None:
+    """A real token with neither the namespaced nor the plain "email" claim
+    (e.g. Auth0 before the Post-Login Action is deployed): email is None, not
+    a crash -- callers must handle a missing email explicitly."""
+    user = await get_current_user(_creds(alice_token_no_email_claim))
+    assert user.email is None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -66,6 +66,8 @@ from tests.fixtures.keycloak.client import (  # noqa: F401
     alice_token,
     bob_token,
     charlie_token,
+    alice_token_namespaced_email,
+    alice_token_no_email_claim,
 )
 
 

--- a/backend/tests/fixtures/keycloak/client.py
+++ b/backend/tests/fixtures/keycloak/client.py
@@ -7,7 +7,11 @@ from httpx import ASGITransport, AsyncClient
 from biosim_server.api.main import app
 from biosim_server.common.auth import auth0 as auth0_module
 from biosim_server.config import get_settings
-from tests.fixtures.keycloak.container import KeycloakTestRealm
+from tests.fixtures.keycloak.container import (
+    NAMESPACED_EMAIL_CLIENT_ID,
+    NO_EMAIL_CLIENT_ID,
+    KeycloakTestRealm,
+)
 from tests.fixtures.keycloak.tokens import fetch_keycloak_token
 
 
@@ -75,4 +79,34 @@ async def charlie_token(keycloak_auth_settings: KeycloakTestRealm) -> str:
         client_id=keycloak_auth_settings.client_id,
         username="charlie",
         password="charlie-password",
+    )
+
+
+@pytest_asyncio.fixture
+async def alice_token_namespaced_email(keycloak_auth_settings: KeycloakTestRealm) -> str:
+    """Real Keycloak access token for Alice from NAMESPACED_EMAIL_CLIENT_ID, whose
+    protocol mappers stamp both the namespaced "https://api.biosimulations.org/email"
+    claim (hardcoded to "Real@Example.com") and a plain "email" claim
+    ("alice@example.com") -- lets tests prove get_current_user prefers the
+    namespaced claim.
+    """
+    return await fetch_keycloak_token(
+        issuer=keycloak_auth_settings.issuer,
+        client_id=NAMESPACED_EMAIL_CLIENT_ID,
+        username="alice",
+        password="alice-password",
+    )
+
+
+@pytest_asyncio.fixture
+async def alice_token_no_email_claim(keycloak_auth_settings: KeycloakTestRealm) -> str:
+    """Real Keycloak access token for Alice from NO_EMAIL_CLIENT_ID, whose protocol
+    mappers include neither the namespaced nor the plain "email" claim -- lets
+    tests prove a missing email claim degrades to None instead of crashing.
+    """
+    return await fetch_keycloak_token(
+        issuer=keycloak_auth_settings.issuer,
+        client_id=NO_EMAIL_CLIENT_ID,
+        username="alice",
+        password="alice-password",
     )

--- a/backend/tests/fixtures/keycloak/container.py
+++ b/backend/tests/fixtures/keycloak/container.py
@@ -17,6 +17,13 @@ from testcontainers.keycloak import KeycloakContainer  # type: ignore[import-unt
 
 REALM_NAME = "biosim-test"
 CLIENT_ID = "biosim-test-client"
+# Same audience/roles mappers as CLIENT_ID, but its own email-claim shape --
+# both a hardcoded namespaced "https://api.biosimulations.org/email" claim and
+# a plain "email" claim -- so tests can prove the namespaced claim wins.
+NAMESPACED_EMAIL_CLIENT_ID = "biosim-test-client-namespaced-email"
+# Same audience/roles mappers as CLIENT_ID, but no email mapper at all -- so
+# tests can prove a token with neither email claim degrades to None.
+NO_EMAIL_CLIENT_ID = "biosim-test-client-no-email"
 AUDIENCE = "biosim-test-api"
 # Matches the "flat-realm-roles" mapper's claim.name in realm.json -- a plain
 # top-level claim, not Keycloak's default nested `realm_access.roles`, so it

--- a/backend/tests/fixtures/keycloak/realm.json
+++ b/backend/tests/fixtures/keycloak/realm.json
@@ -99,6 +99,110 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "biosim-test-client-namespaced-email",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "biosim-test-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "flat-realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "name": "hardcoded-namespaced-email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "https://api\\.biosimulations\\.org/email",
+            "claim.value": "Real@Example.com",
+            "jsonType.label": "String",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "biosim-test-client-no-email",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "defaultClientScopes": ["basic", "profile", "roles", "web-origins", "acr"],
+      "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "biosim-test-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "flat-realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Summary

Adds three integration tests that prove `get_current_user`'s email-claim
precedence/fallback logic against **real, Keycloak-issued tokens** — not
mocked JWTs or a stubbed identity provider. Two new OIDC clients are added to
the existing `testcontainers`-backed Keycloak test realm, each shaped to
produce a specific email-claim configuration on its issued tokens, so the
three failure/precedence modes in `get_current_user` can each be exercised
against a token that actually has that shape.

### What changed

- **`backend/tests/fixtures/keycloak/realm.json`** — two new OIDC clients
  added to the `biosim-test` realm import:
  - `biosim-test-client-namespaced-email` — stamps both a hardcoded
    namespaced `https://api.biosimulations.org/email` claim and a plain
    `email` claim, to prove the namespaced claim wins.
  - `biosim-test-client-no-email` — stamps neither claim, to prove a missing
    email degrades to `None` rather than crashing.
- **`backend/tests/fixtures/keycloak/container.py`** — `NAMESPACED_EMAIL_CLIENT_ID`
  and `NO_EMAIL_CLIENT_ID` constants for the two new clients.
- **`backend/tests/fixtures/keycloak/client.py`** — two new fixtures,
  `alice_token_namespaced_email` and `alice_token_no_email_claim`, each
  fetching a real access token for Alice from one of the new clients via the
  existing `fetch_keycloak_token()` real direct-grant flow.
- **`backend/tests/conftest.py`** — registers the two new fixtures.
- **`backend/tests/common/test_auth0.py`** (new file) — three tests:
  - `test_get_current_user_reads_namespaced_email_claim`
  - `test_get_current_user_falls_back_to_plain_email_claim`
  - `test_get_current_user_no_email_claim_at_all`

  Each calls `get_current_user` directly with a real bearer token and asserts
  on `user.email`. Marked `pytest.mark.integration_local`.
- **`backend/pyproject.toml`** — adds a `[tool.basedpyright]` section
  (`pythonVersion`, `venvPath`, `venv`, `extraPaths`). Editor/type-checker
  config, unrelated to the Keycloak test work but included in this commit.

### Keycloak integration

No mocking of Keycloak, JWKS, or JWT verification is introduced or present.
The existing `keycloak_auth_settings` fixture (unchanged by this PR) points
the app's live `Auth0Settings` at the running `testcontainers` Keycloak
container via `monkeypatch`; the actual verification code in
`common/auth/auth0.py` (JWKS fetch, RS256 signature check, issuer/audience
check) runs unmodified against real tokens fetched from Keycloak's real
`/protocol/openid-connect/token` endpoint. Verified directly: running the new
tests shows live HTTP calls to the Keycloak container's token and JWKS
endpoints, e.g.:

```
POST http://localhost:<port>/realms/biosim-test/protocol/openid-connect/token "HTTP/1.1 200 OK"
GET  http://localhost:<port>/realms/biosim-test/protocol/openid-connect/certs "HTTP/1.1 200 OK"
```

### Test coverage

3 new tests, all passing. Also re-ran the 8 pre-existing
`tests/rbac_demo/test_keycloak_integration.py` end-to-end RBAC tests (same
Keycloak realm, unaffected by this PR) to confirm no regression in the
broader Keycloak test path.

### Testing

```bash
cd backend
uv run ruff check .                                                              # All checks passed
uv run mypy biosim_server tests                                                  # Success: no issues found in 124 source files
uv run python -m pytest tests/common/test_auth0.py tests/rbac_demo/test_keycloak_integration.py \
    -v -m integration_local                                                      # 11 passed
```

All commands run against a real Docker-based Keycloak `testcontainers`
instance (started for this verification); results observed directly, not
assumed.
