### PR TITLE
Auth0 WIP #2: fail-fast config gate, JWKS rotation/outage handling, version-controlled Post-Login Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .idea
+.vscode
+.cursor
 
 # C extensions
 *.so

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pycharm": {
+      "url": "http://127.0.0.1:64462/stream",
+      "type": "http"
+    }
+  }
+}

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -1,0 +1,149 @@
+# Auth0 tenant configuration
+
+Version-controlled source for the Auth0-side configuration that the Platform backend
+depends on at runtime. **Nothing in this directory is deployed by CI or by `kubectl`.**
+Auth0 Actions are dashboard-managed; these files are the reviewed source of truth that the
+dashboard is expected to match.
+
+```
+auth0/
+├── README.md              this file
+└── actions/
+    └── post-login.js      Post-Login Action: stamps the roles + email claims
+```
+
+## Why this exists
+
+The backend reads two custom claims from every access token:
+
+| Claim | Backend setting | Consumed by |
+| --- | --- | --- |
+| `https://api.biosimulations.org/roles` | `AUTH0_ROLES_CLAIM` (`biosim_server/config.py:50`) | `common/auth/roles.py` — `require_roles`, `require_owner_or_admin` |
+| `https://api.biosimulations.org/email` | `AUTH0_EMAIL_CLAIM` (`biosim_server/config.py:58`) | `require_owner_or_admin`'s ownership check |
+
+Auth0 puts **neither** on an access token by default. `actions/post-login.js` does.
+
+**If the Action is absent, disabled, or erroring:** every `require_roles` endpoint returns
+403, no admin exists, and owners cannot cancel or delete their own runs. The backend logs a
+WARNING naming this as the likely cause (`common/auth/auth0.py::_warn_roles_claim_absent`),
+but the HTTP responses are indistinguishable from a legitimate permissions denial.
+
+## Required Auth0-side configuration
+
+All of this is dashboard state. **REQUIRES EXTERNAL ACTION** — none of it can be applied
+from this repository.
+
+### 1. Roles
+
+Create three tenant Roles (Auth0 Dashboard → User Management → Roles), matching
+`common/auth/roles.py:9-11`:
+
+| Role | Purpose |
+| --- | --- |
+| `admin` | Full access; bypasses ownership checks |
+| `publisher` | Elevated, non-admin |
+| `user` | Default, assigned to new sign-ups by the Action |
+
+### 2. Machine-to-Machine application
+
+Create an M2M application authorized for the **Auth0 Management API** with exactly these
+scopes — no more:
+
+- `read:roles`
+- `create:role_members`
+
+This application exists solely so the Action can assign the default role. It is **not** the
+same as the (currently unconfigured) M2M application discussed in TODO #23 for
+`PATCH`/`DELETE /api/v1/me`, which needs `update:users` / `delete:users`. Keep them
+separate: different scopes, different blast radius.
+
+### 3. Action secrets
+
+Dashboard → Actions → Library → *Platform Post-Login* → Secrets. **Never commit these
+values; never paste them into an issue, a PR, or this file.**
+
+| Secret | Value |
+| --- | --- |
+| `AUTH0_DOMAIN` | `<AUTH0_DOMAIN>` — the tenant domain, e.g. `tenant.us.auth0.com` |
+| `M2M_CLIENT_ID` | `<M2M_CLIENT_ID>` — from the application in step 2 |
+| `M2M_CLIENT_SECRET` | `<M2M_CLIENT_SECRET>` — from the same application |
+| `DEFAULT_ROLE_ID` | `<DEFAULT_ROLE_ID>` — the `rol_...` id of the `user` Role |
+
+### 4. Action dependency
+
+Dashboard → the Action → Dependencies → add `auth0` (any 4.x). Actions do not bundle it.
+
+### 5. Flow binding
+
+Dashboard → Actions → Flows → **Login** → drag the Action into the flow → **Apply**.
+An Action that is saved and deployed but not bound to the flow **does not run**. This is the
+single most common way for this configuration to silently stop working.
+
+## Deploying a change
+
+1. Edit `actions/post-login.js` in a branch. Get it reviewed like any other code.
+2. Merge.
+3. In the Auth0 dashboard, open the Action, **replace its entire body** with the file's
+   contents, and click **Deploy**.
+4. Confirm the Action is still bound to the Login flow.
+5. Run the smoke check below.
+6. Note the deployment (date, commit SHA, tenant) in the deploy runbook.
+
+Deploying to the **wrong tenant** is the easy mistake. Confirm the tenant name in the
+dashboard's top-left selector before you paste.
+
+## Smoke check — run after every Action or tenant change
+
+**REQUIRES EXTERNAL ACTION.** Needs a test user who has at least one role assigned.
+
+```bash
+# 1. Obtain an access token for a known-roled user.
+#    Use the frontend login and copy the token from devtools, or, if a
+#    Resource Owner Password grant is enabled on the tenant:
+#      curl -s https://<AUTH0_DOMAIN>/oauth/token \
+#        -H 'content-type: application/json' \
+#        -d '{"grant_type":"password",
+#             "username":"<TEST_USER>","password":"<TEST_PASSWORD>",
+#             "audience":"<AUTH0_AUDIENCE>",
+#             "client_id":"<CLIENT_ID>","scope":"openid email"}'
+
+TOKEN='<ACCESS_TOKEN>'
+
+# 2. Decode the payload and confirm BOTH claims are present and non-empty.
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+#    expect:
+#      "https://api.biosimulations.org/roles": ["user"]      <- non-empty
+#      "https://api.biosimulations.org/email": "..."         <- present
+
+# 3. Confirm the backend agrees.
+curl -s -H "Authorization: Bearer $TOKEN" https://<API_HOST>/api/v1/me
+#    expect: 200 with the user's id/email
+
+# 4. Confirm role gating works end to end.
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TOKEN" https://<API_HOST>/api/v1/demo/private/animal
+#    expect: 200 for a roled user, 403 for a role-less one
+```
+
+If step 2 shows the roles claim **missing**, the Action is not deployed, not bound to the
+Login flow, or uses a different namespace. If it shows `[]`, the Action is running but the
+user has no roles and the default-role assignment failed — check Auth0 Monitoring → Logs for
+`default role assignment failed`.
+
+## Preventing divergence between this repo and the tenant
+
+There is no automated sync today. Three overlapping defences:
+
+1. **Review.** Changes to `actions/post-login.js` go through PR review like any code.
+2. **Runtime assertion.** `common/auth/auth0.py::_warn_roles_claim_absent` logs a WARNING
+   when a validated token carries no roles claim — which is what a deleted, unbound, or
+   renamespaced Action looks like from the backend. It cannot detect *logic* drift, only
+   claim absence.
+3. **Procedure.** The smoke check above is part of the deploy runbook
+   (`backend/CLAUDE.md` → Deploy).
+
+**REQUIRES DECISION — automation.** Auth0 Deploy CLI (`a0deploy`) or the Auth0 Terraform
+provider could make this directory the actual deployed artifact, giving real drift
+detection. Both need tenant-admin credentials in CI, which is a new secret with a large
+blast radius. Not adopted here; recorded so the decision is deliberate. If adopted later,
+this file becomes its input.

--- a/auth0/actions/post-login.js
+++ b/auth0/actions/post-login.js
@@ -1,0 +1,77 @@
+/**
+ * Auth0 Post-Login Action — biosimulations Platform.
+ *
+ * SOURCE OF TRUTH. This file is the reviewed, version-controlled copy of an
+ * Action that actually runs inside Auth0. Committing it here does NOT deploy
+ * it: Auth0 Actions are dashboard-managed. See ../README.md for the deploy
+ * and reconciliation procedure.
+ *
+ * WHY IT EXISTS
+ * -------------
+ * Auth0 access tokens carry neither role assignments nor the user's email by
+ * default. The Platform backend needs both:
+ *   - roles  -> common/auth/roles.py :: require_roles, require_owner_or_admin
+ *   - email  -> require_owner_or_admin's ownership check
+ * Without this Action every role-gated endpoint returns 403, no admin exists,
+ * and owners cannot act on their own simulation runs. The backend logs a
+ * warning when it sees a validated token with no roles claim -- see
+ * common/auth/auth0.py :: _warn_roles_claim_absent.
+ *
+ * IT ALSO ASSIGNS A DEFAULT ROLE
+ * ------------------------------
+ * A brand-new Auth0 user has no roles at all. This Action assigns the tenant's
+ * "user" role on first login via the Management API, so a new sign-up can use
+ * the product immediately instead of 403ing until an admin intervenes.
+ *
+ * REQUIRED ACTION SECRETS (Auth0 Dashboard -> Actions -> this Action -> Secrets).
+ * NEVER commit their values:
+ *   AUTH0_DOMAIN       tenant domain, e.g. tenant.us.auth0.com
+ *   M2M_CLIENT_ID      client id of an M2M application authorized for the
+ *                      Management API with scopes: read:roles, create:role_members
+ *   M2M_CLIENT_SECRET  that application's secret
+ *   DEFAULT_ROLE_ID    the id (rol_...) of the tenant's "user" Role
+ *
+ * REQUIRED ACTION DEPENDENCY (Auth0 Action editor -> Dependencies):
+ *   auth0  (any 4.x)
+ *
+ * CLAIM NAMESPACE
+ * ---------------
+ * NAMESPACE below must match the backend's AUTH0_ROLES_CLAIM and
+ * AUTH0_EMAIL_CLAIM settings exactly (biosim_server/config.py:50, :58 --
+ * defaults "https://api.biosimulations.org/roles" and ".../email"). It is a
+ * namespace URI, not a URL: nothing dereferences it, and it does NOT need to
+ * change if the Auth0 tenant changes. If you change it here, change it in
+ * every overlay's api.env in the same commit.
+ */
+
+const { ManagementClient } = require("auth0");
+
+const NAMESPACE = "https://api.biosimulations.org";
+
+exports.onExecutePostLogin = async (event, api) => {
+    let roles = (event.authorization && event.authorization.roles) || [];
+
+    if (roles.length === 0) {
+        const management = new ManagementClient({
+            domain: event.secrets.AUTH0_DOMAIN,
+            clientId: event.secrets.M2M_CLIENT_ID,
+            clientSecret: event.secrets.M2M_CLIENT_SECRET,
+        });
+        try {
+            await management.users.assignRoles(
+                { id: event.user.user_id },
+                { roles: [event.secrets.DEFAULT_ROLE_ID]}
+            );
+            roles = ["user"];
+        } catch (e) {
+            // Deliberately non-fatal: a Management API blip must not block login.
+            // The user gets a token with no roles and 403s on role-gated endpoints
+            // until their next login. The backend logs the empty claim.
+            console.log("default role assignment failed", e && e.message);
+        }
+    }
+
+    api.accessToken.setCustomClaim('${NAMESPACE}/roles', roles);
+    api.idToken.setCustomClaim('${NAMESPACE}/roles', roles);
+    api.accessToken.setCustomClaim('${NAMESPACE}/email', event.user.email);
+};

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,44 +50,19 @@ AUTH0_DOMAIN=dev-bu7yo7484tyxu6a1.us.auth0.com
 AUTH0_AUDIENCE=https://api.biosimulations.org
 AUTH0_ISSUER=https://dev-bu7yo7484tyxu6a1.us.auth0.com/
 
-# Custom claims under which access tokens carry role names and email (see
-# biosim_server/rbac_demo and common/auth/roles.py for the require_roles(...)
-# dependency that reads the roles claim). Auth0 access tokens include neither
-# by default -- roles need an assigned Auth0 Role to exist at all, and email
-# lives only on the ID token / userinfo unless stamped on separately. Add a
-# post-login Action in the Auth0 dashboard (Actions -> Flows -> Login) that
-# sets both claims and assigns the default "user" role to brand-new users
-# (requires adding the `auth0` npm dependency in the Action editor, plus
-# Action secrets AUTH0_DOMAIN/M2M_CLIENT_ID/M2M_CLIENT_SECRET for an M2M app
-# authorized for the Management API with read:roles/create:role_members, and
-# DEFAULT_ROLE_ID for the "user" Role's id):
-#   const { ManagementClient } = require("auth0");
+# Custom claims carrying role names and email. Auth0 access tokens include
+# NEITHER by default: roles require an assigned Auth0 Role to exist at all, and
+# email lives only on the ID token / userinfo unless stamped on separately.
+# Both are added by a Post-Login Action.
 #
-#   exports.onExecutePostLogin = async (event, api) => {
-#     const namespace = "https://api.biosimulations.org";
-#     let roles = (event.authorization && event.authorization.roles) || [];
+# THE ACTION IS VERSION-CONTROLLED: auth0/actions/post-login.js (repo root).
+# See auth0/README.md for the required Action secrets, the M2M scopes, the
+# dashboard deploy procedure, and the post-deploy smoke check.
 #
-#     if (roles.length === 0) {
-#       const management = new ManagementClient({
-#         domain: event.secrets.AUTH0_DOMAIN,
-#         clientId: event.secrets.M2M_CLIENT_ID,
-#         clientSecret: event.secrets.M2M_CLIENT_SECRET,
-#       });
-#       try {
-#         await management.users.assignRoles(
-#           { id: event.user.user_id },
-#           { roles: [event.secrets.DEFAULT_ROLE_ID] }
-#         );
-#         roles = ["user"];
-#       } catch (e) {
-#         console.log("default role assignment failed", e && e.message);
-#       }
-#     }
-#
-#     api.accessToken.setCustomClaim(`${namespace}/roles`, roles);
-#     api.idToken.setCustomClaim(`${namespace}/roles`, roles);
-#     api.accessToken.setCustomClaim(`${namespace}/email`, event.user.email);
-#   };
+# These two values must match the namespace the Action uses. They are namespace
+# URIs, not URLs -- nothing dereferences them -- and they do not need to change
+# if the Auth0 tenant changes.
+
 AUTH0_ROLES_CLAIM=https://api.biosimulations.org/roles
 AUTH0_EMAIL_CLAIM=https://api.biosimulations.org/email
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,14 @@ MONGODB_URI=mongodb://localhost:27017
 # (kustomize overlays) set this to the deployed frontend host(s).
 # CORS_EXTRA_ORIGINS=https://example.org,https://example-dev.org
 
+# Startup gate (biosim_server/config.py :: Auth0Settings.required). True by
+# default: the API refuses to start when AUTH0_DOMAIN/AUTH0_AUDIENCE are
+# missing or malformed, so a misconfigured deployment crash-loops visibly
+# rather than reporting healthy and failing every authenticated request.
+# Set to false only to run deliberately without an identity provider --
+# every endpoint behind get_current_user then returns 503.
+# AUTH_REQUIRED=true
+
 AUTH0_DOMAIN=dev-bu7yo7484tyxu6a1.us.auth0.com
 AUTH0_AUDIENCE=https://api.biosimulations.org
 AUTH0_ISSUER=https://dev-bu7yo7484tyxu6a1.us.auth0.com/

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -221,6 +221,43 @@ These point at the public biosimulations.org services. Defaults are production; 
 |---|---|---|
 | `CORS_EXTRA_ORIGINS` | _empty_ | Comma-separated list of additional CORS origins appended to the built-in allowlist in `api/main.py`. **Required** for every deployment so the deployed frontend host (e.g. `https://biosim.biosimulations.org`) is allowed. The built-in list only covers local-dev loopbacks and cross-org trusted services — deploy-specific URLs are not hardcoded by design. |
 
+### Authentication (Auth0)
+
+All values are **non-secret** and belong in each overlay's `api.env` ConfigMap, never in a
+sealed secret. The Management API credentials at the bottom are the exception — they are
+credentials, are unset in every overlay today, and are tracked separately (TODO #23).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AUTH_REQUIRED` | `true` | Startup gate. When true, the API refuses to start unless the Auth0 configuration below is complete and well-formed. Set to `false` only to run deliberately without an identity provider. |
+| `AUTH0_DOMAIN` | _empty_ | **Bare hostname** of the Auth0 tenant, e.g. `tenant.us.auth0.com`. The issuer (`https://{domain}/`) and JWKS URL (`https://{domain}/.well-known/jwks.json`) are derived from it. A URL or a trailing slash here is a configuration error and is rejected at startup. |
+| `AUTH0_AUDIENCE` | _empty_ | The API identifier tokens must carry in `aud`. |
+| `AUTH0_ISSUER` | _derived_ | Explicit issuer override. Needed only for a non-Auth0 OIDC provider whose issuer does not follow Auth0's convention (the Keycloak realm used in tests). Must be set together with `AUTH0_JWKS_URI`. |
+| `AUTH0_JWKS_URI` | _derived_ | Explicit JWKS URL override. See above. |
+| `AUTH0_ROLES_CLAIM` | `https://api.biosimulations.org/roles` | Namespaced claim carrying role names. **Stamped by the Auth0 Post-Login Action** (`auth0/actions/post-login.js`) — without that Action the claim never arrives, every `require_roles` endpoint returns 403, and no admin exists. |
+| `AUTH0_EMAIL_CLAIM` | `https://api.biosimulations.org/email` | Namespaced claim carrying the user's email. Also stamped by the Action; `get_current_user` falls back to a plain `email` claim for providers that include one. |
+| `AUTH0_MANAGEMENT_CLIENT_ID` | _empty_ | M2M credentials for `PATCH`/`DELETE /api/v1/me`. **Secret** — sealed-secret path only. Unset in every cluster today, so those endpoints return 503. |
+| `AUTH0_MANAGEMENT_CLIENT_SECRET` | _empty_ | See above. |
+
+**Per-cluster configuration:**
+
+| Overlay | Auth0 configuration | Notes |
+|---|---|---|
+| `biosim-gke` | tenant + audience set | Production tier. |
+| `biosim-rke` | tenant + audience set | Prod tier; also backs the `biosim-rke-frontend-dev` preview frontend. |
+| `biosim-local` | _record the Step 2 decision here_ | |
+
+**Failure modes:**
+
+| Condition | Result |
+|---|---|
+| Missing/malformed config, `AUTH_REQUIRED=true` | Pod refuses to start; `kubectl logs` names the variable. |
+| Missing/malformed config, `AUTH_REQUIRED=false` | Pod starts; endpoints behind `get_current_user` return **503**. |
+| Auth0 unreachable, warm JWKS cache | Tokens still validate for up to 24 h; a WARN is logged per request. |
+| Auth0 unreachable, cold JWKS cache | **503** with `Retry-After: 10`. |
+| Invalid, expired, or wrongly-audienced token | **401**. |
+| Valid token, missing role | **403**. |
+
 ## Testing
 
 - **Framework:** pytest with pytest-asyncio

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -290,6 +290,20 @@ Backend release steps (run from repo root unless noted):
 > considerations" for the full rationale and the longer-term `workflow.patched`
 > pattern.
 
+<!-- -->
+
+> **Do not roll the `api` Deployment during an Auth0 outage.** The JWKS cache is
+> per-process and in-memory. A running pod serves cached signing keys for up to 24 hours
+> after the identity provider becomes unreachable, so an Auth0 incident is usually
+> invisible to users. A restarted pod starts with an empty cache and returns
+> `503 Authentication temporarily unavailable` on every authenticated request until Auth0
+> is reachable again. `strategy: Recreate` (kustomize/base/api.yaml) means a rollout
+> terminates the old pod first, so this is not recoverable mid-rollout.
+>
+> **The exception:** if you are told an Auth0 signing key has been **compromised**, roll the
+> pods immediately. A restart is the only way to purge a revoked key from the stale cache
+> before the 24-hour bound expires.
+
 1. **Bump version + tag** (bumps `version.py` + `pyproject.toml`, commits, tags `backend-vX.Y.Z`):
    ```bash
    bash backend/scripts/bump-backend.sh patch      # or minor|major|X.Y.Z

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -323,6 +323,62 @@ Backend release steps (run from repo root unless noted):
    ```bash
    kubectl get pods -n biosim-gke
    ```
+6. **Verify authentication end to end** (required after any deploy that touches auth
+   configuration, and after any change to the Auth0 tenant or its Post-Login Action):
+
+   ```bash
+   # a. The startup gate passed
+   kubectl logs -n <namespace> deploy/api | grep 'Auth0 configuration validated'
+
+   # b. An invalid token is a 401 -- not a 500, not a 503
+   curl -s -o /dev/null -w '%{http_code}\n' \
+     -H 'Authorization: Bearer not-a-jwt' https://<API_HOST>/api/v1/me
+
+   # c. A known-roled user's token still carries the roles claim.
+   #    Full procedure, including how to obtain the token: auth0/README.md
+   #    -> "Smoke check". This is the check that catches a Post-Login Action
+   #    that was deleted, disabled, unbound from the Login flow, or deployed
+   #    to the wrong tenant -- none of which produce any other symptom until
+   #    a user reports a 403.
+   curl -s -H "Authorization: Bearer <TOKEN>" https://<API_HOST>/api/v1/me
+
+   # d. No pod is warning about the roles claim
+   kubectl logs -n <namespace> deploy/api --since=10m | grep -i 'roles claim'
+   #    expect: no output
+   ```
+
+   Also confirm no `AUTH_REQUIRED=false` reached a production overlay:
+
+   ```bash
+   grep -rn 'AUTH_REQUIRED' kustomize/config/
+
+#### Auth0 tenant decision (TODO #6)
+
+**Decision:** <RATIFY the dev tenant | MIGRATE to a production tenant>
+**Date:** <YYYY-MM-DD>
+**Decided by:** <name>
+
+**Tenant:** `<AUTH0_DOMAIN>`
+**Audience:** `<AUTH0_AUDIENCE>`
+**Claim namespaces:** `https://api.biosimulations.org/roles`, `.../email`
+(tenant-independent; must match `auth0/actions/post-login.js`)
+
+**Rationale:** <why>
+
+<If ratifying, also record:>
+
+- Accepted rate-limit ceiling: <value, from the Auth0 dashboard's tenant settings>
+- Accepted consequence: the `dev-` prefix appears in the issuer and in user-visible
+  login URLs.
+- Revisit trigger: <e.g. "before public launch", "at N registered users">
+
+<If migrating, also record:>
+
+- Cutover date: <YYYY-MM-DD>
+- Old tenant retained until: <YYYY-MM-DD>
+- Applications re-created: SPA client id `<CLIENT_ID>`, M2M for the Action,
+  M2M for the Management API (TODO #23) if enabled.
+
 
 ## Important Notes
 

--- a/backend/biosim_server/api/main.py
+++ b/backend/biosim_server/api/main.py
@@ -94,7 +94,7 @@ APP_SERVERS: list[dict[str, str]] = [
 
 router = APIRouter()
 
-
+"""
 def _warn_if_auth0_misconfigured() -> None:
     auth0 = get_settings().auth0
     if not auth0.domain or not auth0.audience:
@@ -102,11 +102,57 @@ def _warn_if_auth0_misconfigured() -> None:
             "AUTH0_DOMAIN/AUTH0_AUDIENCE not set -- all endpoints behind get_current_user/"
             "get_optional_user will reject every bearer token with 401."
         )
+"""
 
+def _validate_auth0_configuration() -> None:
+    """
+    Startup gate: refuse to serve traffic with an unusable Auth0 configuration.
+
+    Replaces _warn_if_auth0_misconfigured(), which both under-reacted (the pod
+    started anyway, reported healthy, and failed every authenticated request)
+    and misdescribed the failure -- it promised a 401, which has never been
+    what happens.
+
+    Raising here propagates out of `lifespan`, so uvicorn exits non-zero and
+    Kubernetes shows CrashLoopBackOff with the reason in `kubectl logs`. That
+    is the loudest signal available, and a cluster that cannot authenticate
+    anyone should be using it.
+    """
+    auth0 = get_settings().auth0
+    errors = auth0.configuration_errors()
+
+    if not auth0.required:
+        if errors:
+            logger.warning(
+                "AUTH_REQUIRED=false: starting with an incomplete Auth0 configuration "
+                "(%s). Every endpoint behind get_current_user/get_optional_user will "
+                "return 503 (Authentication temporarily unavailable); no request will "
+                "be authenticated in this deployment.",
+                "; ".join(errors),
+            )
+        else:
+            logger.warning(
+                "AUTH_REQUIRED=false: Auth0 startup validation skipped, though the "
+                "configuration looks complete."
+            )
+        return
+    if errors:
+        raise RuntimeError(
+            "Auth0 configuration is incomplete or invalid; refusing to start. "
+            + "; ".join(errors)
+            + ". Fix this cluster's kustomize/config/<cluster>/api.env, or set "
+            "AUTH_REQUIRED=false to run this deployment without authentication."
+        )
+    logger.info(
+        "Auth0 configuration validated: issuer=%s audience=%s",
+        auth0.issuer_url(),
+        auth0.audience,
+    )
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
-    _warn_if_auth0_misconfigured()
+    #_warn_if_auth0_misconfigured()
+    _validate_auth0_configuration()
     await init_standalone()
     yield
     await shutdown_standalone()

--- a/backend/biosim_server/common/auth/auth0.py
+++ b/backend/biosim_server/common/auth/auth0.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import time
 from typing import Any
 
@@ -8,23 +10,254 @@ from jose import jwt  # type: ignore[import-untyped]
 
 from biosim_server.config import get_settings
 
+logger = logging.getLogger(__name__)
+
 bearer_scheme = HTTPBearer(auto_error=False)
 
-_jwks_cache: dict[str, Any] = {"keys": None, "fetched_at": 0.0}
+# How long a successfully fetched JWKS document is treated as fresh. Unchanged
+# from the original implementation.
 _JWKS_TTL_SECONDS = 3600
+# Hard ceiling on how long an expired document may still be served while
+# refreshes keep failing (stale-while-revalidate). Well inside Auth0's
+# rotation overlap -- a key that has been rotated *out* stays published in the
+# JWKS for far longer than a day -- so a key cached within this window is still
+# a key the tenant published. See the security analysis before changing it.
+_JWKS_STALE_MAX_AGE_SECONDS = 86400
+# After a failed fetch, suppress further outbound attempts for this long. This
+# is the negative cache: it turns "one outbound request per inbound request"
+# into "one outbound request per window per process".
+_JWKS_FAILURE_BACKOFF_SECONDS = 10
+# Minimum interval between *forced* refreshes triggered by an unknown `kid`.
+# Without it, a flood of tokens carrying bogus kids becomes an amplification
+# vector against the identity provider. Not optional.
+_JWKS_KID_REFRESH_COOLDOWN_SECONDS = 60
+# Value advertised in the Retry-After header of the 503 we return when no
+# usable key set exists. Matched to the failure backoff so a client that
+# honours it comes back at roughly the moment the next attempt is allowed.
+_JWKS_RETRY_AFTER_SECONDS = _JWKS_FAILURE_BACKOFF_SECONDS
+# Rate limit on the "roles claim did not arrive" warning (P0 #4), so a
+# misconfigured tenant produces a visible signal rather than a log flood.
+_ROLES_CLAIM_WARN_INTERVAL_SECONDS = 300
+
+# Module-level JWKS cache. The name and the "keys"/"fetched_at" entries are
+# unchanged from the original implementation because
+# tests/fixtures/keycloak/client.py resets them by hand; the three new entries
+# carry the negative-cache and cooldown state.
+_jwks_cache: dict[str, Any] = {
+    "keys": None,                    # last successfully fetched JWKS document
+    "fetched_at": 0.0,               # when that fetch succeeded
+    "last_failure_at": 0.0,          # when a fetch last failed (0.0 = no active backoff)
+    "last_forced_refresh_at": 0.0,   # when an unknown `kid` last forced a refresh
+}
+# Serialises refreshes so N concurrent cache misses produce one outbound fetch,
+# not N. Mirrors the double-checked pattern already used for the Management API
+# token in auth0_management.py:25, 40-46. Deliberately NOT held across token
+# validation -- only across the fetch -- so jwt.decode stays fully parallel.
+_jwks_refresh_lock = asyncio.Lock()
+# Rate-limiter state for the roles-claim assertion (P0 #4).
+_auth_warning_state: dict[str, float] = {"roles_claim_warned_at": 0.0}
 
 
-async def _get_jwks() -> dict[str, Any]:
+def _reset_jwks_cache() -> None:
+    """Clear all cached JWKS state. Test-only affordance.
+
+    Tests previously reset `_jwks_cache["keys"]` and `["fetched_at"]` by hand
+    (tests/fixtures/keycloak/client.py:34-35). With backoff and cooldown state
+    in the same dict, resetting only those two would leak an armed backoff
+    into the next test, so the reset belongs next to the state it clears.
+    """
+    _jwks_cache["keys"] = None
+    _jwks_cache["fetched_at"] = 0.0
+    _jwks_cache["last_failure_at"] = 0.0
+    _jwks_cache["last_forced_refresh_at"] = 0.0
+    _auth_warning_state["roles_claim_warned_at"] = 0.0
+
+
+def _jwks_unavailable() -> HTTPException:
+    """The 503 returned when no usable key set exists.
+
+    Deliberately a *factory*, not a raise: several call sites need it and the
+    Retry-After value must be identical at every one of them. The detail text
+    is generic -- it names no URL, no exception, and no token material.
+    """
+    return HTTPException(
+        status.HTTP_503_SERVICE_UNAVAILABLE,
+        "Authentication temporarily unavailable",
+        headers={"Retry-After": str(_JWKS_RETRY_AFTER_SECONDS)},
+    )
+
+
+def _backoff_active(now: float) -> bool:
+    """True while the negative cache is suppressing outbound JWKS fetches."""
+    last_failure: float = _jwks_cache["last_failure_at"]
+    return last_failure > 0.0 and (now - last_failure) < _JWKS_FAILURE_BACKOFF_SECONDS
+
+
+def _usable_jwks(now: float) -> dict[str, Any]:
+    """Return the cached document if it is fresh, or stale but within the bound.
+
+    Raises the 503 when the cache is empty or has aged past
+    _JWKS_STALE_MAX_AGE_SECONDS. This is the single place that decides
+    "serve stale" versus "refuse to serve", so the staleness policy cannot
+    drift between the TTL path and the failure path.
+    """
+    cached: dict[str, Any] | None = _jwks_cache["keys"]
+    if cached is not None:
+        age = now - float(_jwks_cache["fetched_at"])
+        if age <= _JWKS_TTL_SECONDS:
+            return cached
+        if age <= _JWKS_STALE_MAX_AGE_SECONDS:
+            logger.warning(
+                "Serving stale JWKS (age %.0fs, TTL %ds): refresh against the identity "
+                "provider is failing. Tokens signed with a newly rotated key will be "
+                "rejected until a refresh succeeds.",
+                age,
+                _JWKS_TTL_SECONDS,
+            )
+            return cached
+        logger.error(
+            "Cached JWKS is %.0fs old, past the %ds staleness bound -- refusing to use it.",
+            age,
+            _JWKS_STALE_MAX_AGE_SECONDS,
+        )
+    raise _jwks_unavailable()
+
+
+async def _fetch_jwks_locked(now: float) -> bool:
+    """Fetch and store the JWKS document. The caller MUST hold _jwks_refresh_lock.
+
+    Returns True on success. On failure it arms the negative cache and returns
+    False rather than raising -- the caller may still have a stale document it
+    can legitimately serve, and that decision belongs to _usable_jwks().
+    """
     settings = get_settings().auth0
-    now = time.time()
-    if _jwks_cache["keys"] is None or now - _jwks_cache["fetched_at"] > _JWKS_TTL_SECONDS:
+    try:
         async with httpx.AsyncClient() as client:
             resp = await client.get(settings.jwks_url(), timeout=5.0)
             resp.raise_for_status()
-            _jwks_cache["keys"] = resp.json()
-            _jwks_cache["fetched_at"] = now
-    keys: dict[str, Any] = _jwks_cache["keys"]
-    return keys
+            document = resp.json()
+        if not isinstance(document, dict) or not isinstance(document.get("keys"), list):
+            raise ValueError("response body is not a JWKS document")
+    except Exception as e:
+        _jwks_cache["last_failure_at"] = now
+        logger.error(
+            "JWKS fetch failed (%s); suppressing further attempts for %ds.",
+            type(e).__name__,
+            _JWKS_FAILURE_BACKOFF_SECONDS,
+        )
+        return False
+    _jwks_cache["keys"] = document
+    _jwks_cache["fetched_at"] = now
+    _jwks_cache["last_failure_at"] = 0.0
+    logger.info("JWKS refreshed: %d key(s).", len(document["keys"]))
+    return True
+
+
+def _select_rsa_key(jwks: dict[str, Any], kid: str | None) -> dict[str, str] | None:
+    """Pick the RSA public key matching `kid`, or None.
+
+    Replaces the inline generator at the original auth0.py:52-59. Same
+    selection rule (match on `kid`), but every field access is guarded: the
+    original indexed k["kty"], k["kid"], k["use"], k["n"], k["e"] directly, so
+    a JWKS entry missing any of them raised KeyError -> HTTP 500. `use` in
+    particular is optional in RFC 7517 and is absent from key sets produced by
+    python-jose's own jwk.construct(...).public_key().to_dict().
+    """
+    if not kid:
+        return None
+    for key in jwks.get("keys", []):
+        if not isinstance(key, dict) or key.get("kid") != kid or key.get("kty") != "RSA":
+            continue
+        n, e = key.get("n"), key.get("e")
+        if not isinstance(n, str) or not isinstance(e, str):
+            continue
+        return {"kty": "RSA", "kid": kid, "use": key.get("use") or "sig", "n": n, "e": e}
+    return None
+
+
+async def _get_jwks() -> dict[str, Any]:
+    """Return a usable JWKS document, refreshing it when the cached copy expired.
+
+    Never raises for an ordinary identity-provider failure while a usable
+    cached copy exists. Raises HTTP 503 (with Retry-After) only when there is
+    nothing safe to serve.
+    """
+    now = time.time()
+    cached: dict[str, Any] | None = _jwks_cache["keys"]
+    if cached is not None and (now - float(_jwks_cache["fetched_at"])) <= _JWKS_TTL_SECONDS:
+        return cached
+
+    if _backoff_active(now):
+        # A recent attempt failed. Do not touch the identity provider; serve
+        # stale if we can, 503 if we cannot.
+        return _usable_jwks(now)
+
+    async with _jwks_refresh_lock:
+        # Double-checked: another coroutine may have refreshed while we waited
+        # on the lock. Same pattern as auth0_management.py:40-46.
+        now = time.time()
+        cached = _jwks_cache["keys"]
+        if cached is not None and (now - float(_jwks_cache["fetched_at"])) <= _JWKS_TTL_SECONDS:
+            return cached
+        if not _backoff_active(now):
+            await _fetch_jwks_locked(now)
+        return _usable_jwks(time.time())
+
+
+async def _force_jwks_refresh() -> dict[str, Any] | None:
+    """Force one JWKS refresh after a `kid` miss, subject to a cooldown.
+
+    Returns whatever document is cached afterwards -- refreshed, unchanged, or
+    None if the cache was empty and the refresh failed. The caller re-runs key
+    selection against it, which is why this returns the current document rather
+    than a success flag: two concurrent `kid` misses then both benefit from the
+    single refresh the first one performed.
+    """
+    async with _jwks_refresh_lock:
+        now = time.time()
+        last_forced: float = _jwks_cache["last_forced_refresh_at"]
+        cooldown_active = (
+            last_forced > 0.0 and (now - last_forced) < _JWKS_KID_REFRESH_COOLDOWN_SECONDS
+        )
+        if not cooldown_active and not _backoff_active(now):
+            # Stamp the cooldown BEFORE fetching: a failed forced refresh must
+            # consume the window too, or a flood of bogus kids retries forever.
+            _jwks_cache["last_forced_refresh_at"] = now
+            await _fetch_jwks_locked(now)
+        document: dict[str, Any] | None = _jwks_cache["keys"]
+        return document
+
+
+def _warn_roles_claim_absent(claim: str, claim_present: bool) -> None:
+    """Runtime assertion that the Auth0 Post-Login Action is actually live (P0 #4).
+
+    Both custom claims the backend depends on are stamped by an Auth0
+    Post-Login Action (see auth0/actions/post-login.js). If that Action is
+    absent, disabled, or erroring, every require_roles endpoint returns 403 and
+    no admin exists -- a silent, total failure that presents as a permissions
+    bug. This turns it into a named log line.
+
+    Rate-limited: a tenant in this state produces one warning per token
+    otherwise, which is a log flood rather than a signal.
+    """
+    now = time.time()
+    if (now - _auth_warning_state["roles_claim_warned_at"]) < _ROLES_CLAIM_WARN_INTERVAL_SECONDS:
+        return
+    _auth_warning_state["roles_claim_warned_at"] = now
+    if claim_present:
+        logger.warning(
+            "Validated token carries an empty %r claim: the Auth0 Action is stamping the "
+            "claim, but this user has no roles assigned. require_roles endpoints will 403.",
+            claim,
+        )
+    else:
+        logger.warning(
+            "Validated token carries no %r claim at all: the Auth0 Post-Login Action that "
+            "stamps it is probably not deployed on this tenant, or AUTH0_ROLES_CLAIM does "
+            "not match the namespace the Action uses. Every require_roles endpoint will "
+            "403 and no admin will exist.",
+            claim,
+        )
 
 
 class AuthenticatedUser:
@@ -49,15 +282,20 @@ async def get_current_user(
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Malformed token")
 
     jwks = await _get_jwks()
-    rsa_key = next(
-        (
-            {"kty": k["kty"], "kid": k["kid"], "use": k["use"], "n": k["n"], "e": k["e"]}
-            for k in jwks["keys"]
-            if k["kid"] == unverified_header.get("kid")
-        ),
-        None,
-    )
+    kid = unverified_header.get("kid")
+    rsa_key = _select_rsa_key(jwks, kid)
     if rsa_key is None:
+        # Auth0 rotates signing keys without notice. Before rejecting the
+        # token, force one refresh (cooldown-guarded) and look again -- this is
+        # what turns a rotation from an hour-long outage into a single slow
+        # request. If the kid is still absent, the 401 below stands.
+        refreshed = await _force_jwks_refresh()
+        if refreshed is not None:
+            rsa_key = _select_rsa_key(refreshed, kid)
+    if rsa_key is None:
+        # The kid comes from an unverified header and is attacker-controlled,
+        # so it is deliberately not echoed into the log line.
+        logger.warning("Rejecting token: its signing key id is not in the JWKS.")
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Unknown signing key")
 
     try:
@@ -77,7 +315,14 @@ async def get_current_user(
 
     roles = payload.get(settings.roles_claim, [])
     if not isinstance(roles, list):
+        logger.warning(
+            "Roles claim %r is present but is not a list; treating the token as having "
+            "no roles.",
+            settings.roles_claim,
+        )
         roles = []
+    if not roles:
+        _warn_roles_claim_absent(settings.roles_claim, settings.roles_claim in payload)
     # Real Auth0 access tokens don't carry a plain "email" claim -- it has to be
     # stamped on via a Post-Login Action as the namespaced settings.email_claim
     # (see config.py). Fall back to plain "email" for OIDC providers that do put
@@ -94,8 +339,19 @@ async def get_optional_user(
     that stay open to anonymous callers while still trusting a token when one is given.
     """
     if credentials is None:
+        # No token at all: a genuinely anonymous caller. Note that this path
+        # never touches the identity provider, so anonymous access keeps
+        # working normally during an Auth0 outage.
         return None
     try:
         return await get_current_user(credentials)
-    except HTTPException:
+    except HTTPException as e:
+        if e.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+            # An infrastructure failure must not silently downgrade an
+            # authenticated caller to anonymous -- that would change the
+            # authorization outcome (ownership checks, role gates) based on
+            # an Auth0 outage. Propagate it as the 503 it is.
+            raise
+        # 401s stay swallowed: a bad or expired token on an optional-auth
+        # endpoint is still just "not authenticated".
         return None

--- a/backend/biosim_server/config.py
+++ b/backend/biosim_server/config.py
@@ -25,6 +25,10 @@ if os.getenv(ENV_SECRET_ENV_FILE) is not None and os.path.exists(str(os.getenv(E
 class Auth0Settings(BaseSettings):
     domain: str = Field(default="", alias="AUTH0_DOMAIN")
     audience: str = Field(default="", alias="AUTH0_AUDIENCE")
+    # Startup gate: when true, the API refuses to start with an incomplete or
+    # malformed configuration (see _validate_auth0_configuration in api/main.py).
+    # Set false only to run deliberately without an identity provider.
+    required: bool = Field(default=True, alias="AUTH_REQUIRED")
     algorithms: list[str] = ["RS256"]
     # get_current_user derives the expected JWT issuer and JWKS URL from
     # `domain` using Auth0's own convention ("https://{domain}/" and
@@ -64,6 +68,49 @@ class Auth0Settings(BaseSettings):
 
     def jwks_url(self) -> str:
         return self.jwks_uri or f"https://{self.domain}/.well-known/jwks.json"
+
+    def configuration_errors(self) -> list[str]:
+        """
+        Names every reason these settings could not verify a token.
+
+        Returns an empty list when the configuration is usable. Pure and free
+        of side effects, so the startup gate, the tests, and any future /ready
+        check can all call it without coordinating.
+
+        Two shapes are accepted:
+          * the normal Auth0 one -- a bare AUTH0_DOMAIN, from which issuer_url()
+            and jwks_url() are derived; or
+          * explicit AUTH0_ISSUER *and* AUTH0_JWKS_URI overrides, which is how
+            a non-Auth0 OIDC provider is configured (the Keycloak realm in
+            tests/fixtures/keycloak does exactly this).
+        Half of the second shape is not a valid configuration and is reported.
+        """
+        errors: list[str] = []
+
+        if not self.audience:
+            errors.append("AUTH0_AUDIENCE is not set")
+
+        if not self.domain:
+            if not self.issuer:
+                errors.append(
+                    "AUTH0_DOMAIN is not set and no AUTH0_ISSUER override was provided"
+                )
+            if not self.jwks_uri:
+                errors.append(
+                    "AUTH0_DOMAIN is not set and no AUTH0_JWKS_URI override was provided"
+                )
+        elif "://" in self.domain or "/" in self.domain:
+            errors.append(
+                f"AUTH0_DOMAIN must be a bare hostname such as "
+                f"'tenant.us.auth0.com', not a URL or a path: {self.domain!r}"
+            )
+        elif self.domain != self.domain.strip() or "." not in self.domain:
+            errors.append(
+                f"AUTH0_DOMAIN does not look like a hostname: {self.domain!r}"
+            )
+        if not self.algorithms:
+            errors.append("the JWT algorithm allowlist resolved to an empty list")
+        return errors
 
 
 class Settings(BaseSettings):

--- a/backend/tests/api/test_auth_error_responses.py
+++ b/backend/tests/api/test_auth_error_responses.py
@@ -1,0 +1,272 @@
+"""
+The authentication error taxonomy, asserted at the HTTP layer.
+
+The unit tests in tests/common/test_auth0_jwks.py assert what get_current_user
+raises. These assert what a client actually receives: the status line, the
+Retry-After header, and the response body -- through the real FastAPI app, its
+exception handlers, and its middleware stack.
+
+Both layers are needed. A dependency can raise a perfectly good
+HTTPException(503, headers=...) and still have the header dropped by a
+middleware or an exception handler; only a through-the-app test catches that.
+"""
+
+from typing import Any, Callable, Iterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from biosim_server.api.main import app
+from biosim_server.common.auth import auth0 as auth0_module
+
+from biosim_server.config import get_settings
+from tests.fixtures.jwks_fixtures import (
+    AUDIENCE,
+    ISSUER,
+    FakeClock,
+    FakeJwksEndpoint,
+    connect_error,
+    jwks_document,
+    make_key,
+)
+
+# /api/v1/demo/private/me sits behind get_current_user with no role
+# requirement, which makes it the narrowest probe of the authentication path
+# available (rbac_demo/router.py:41-48). If the rbac_demo router is ever gated
+# or removed (TODO #20, P2), repoint these at /api/v1/me -- the auth
+# dependency is identical.
+
+PROTECTED_URL = "/api/v1/demo/private/me"
+
+KEY = make_key("kid-http")
+
+@pytest.fixture(autouse=True)
+def _clean_jwks_cache() -> Iterator[None]:
+    auth0_module._reset_jwks_cache()
+    yield
+    auth0_module._reset_jwks_cache()
+
+@pytest.fixture
+def auth_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "issuer", ISSUER)
+    monkeypatch.setattr(settings, "jwks_uri", "https://idp.invalid/.well-known/jwks.json")
+    monkeypatch.setattr(settings, "audience", AUDIENCE)
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, endpoint: FakeJwksEndpoint, clock: FakeClock
+) -> None:
+
+    monkeypatch.setattr(
+        auth0_module.httpx,  # type: ignore[attr-defined]
+        "AsyncClient",
+        endpoint.client_factory(),
+    )
+    monkeypatch.setattr(auth0_module, "time", clock)
+
+# --------------------------------------------------------------------------
+# 503: infrastructure failure
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_idp_outage_returns_503_with_retry_after_header(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The P0 #2 headline assertion, from a client's point of view."""
+
+    _install(monkeypatch, FakeJwksEndpoint(responses=[connect_error]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL, headers={"Authorization": f"Bearer {KEY.token()}"}
+        )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "10"
+    assert response.json() == {"detail": "Authentication temporarily unavailable"}
+
+@pytest.mark.asyncio
+async def test_503_body_leaks_nothing(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The error body must not name the JWKS URL, the exception, or the token."""
+
+    token = KEY.token()
+    _install(monkeypatch, FakeJwksEndpoint(responses=[connect_error]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL, headers={"Authorization": f"Bearer {token}"}
+        )
+
+    body = response.text
+    assert "idp.invalid" not in body
+    assert "ConnectError" not in body
+    assert "jwks" not in body.lower()
+    assert token[:20] not in body
+
+@pytest.mark.asyncio
+async def test_optional_auth_endpoint_also_returns_503(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An IdP outage must not silently downgrade a token-bearing caller to anonymous.
+
+    POST /simulations/run uses get_optional_user (simulations/router.py:45-47).
+    Before the fix, a token-bearing caller during an outage would have been
+    treated as anonymous and their run recorded without an owner.
+    """
+    _install(monkeypatch, FakeJwksEndpoint(responses=[connect_error]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.post(
+            "/simulations/run",
+            json={"omex_id": "does-not-matter", "simulators": []},
+            headers={"Authorization": f"Bearer {KEY.token()}"},
+        )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "10"
+
+
+# --------------------------------------------------------------------------
+# 401: token faults -- must NOT gain a Retry-After
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_missing_token_is_401_without_retry_after() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(PROTECTED_URL)
+
+    assert response.status_code == 401
+    assert "retry-after" not in response.headers
+
+@pytest.mark.asyncio
+async def test_malformed_token_is_401_without_retry_after(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A garbage token is rejected before any JWKS fetch is attempted."""
+    endpoint = FakeJwksEndpoint(responses=[lambda: jwks_document(KEY)])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL, headers={"Authorization": "Bearer not-a-jwt"}
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Malformed token"}
+    assert "retry-after" not in response.headers
+    assert endpoint.call_count == 0
+
+@pytest.mark.asyncio
+async def test_expired_token_is_401_not_503(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A client fault must never be reported as infrastructure fault."""
+    document = jwks_document(KEY)
+    _install(monkeypatch, FakeJwksEndpoint(responses=[lambda: document]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL,
+            headers={"Authorization": f"Bearer {KEY.token(expires_in=-60)}"},
+        )
+    
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Token expired"}
+
+@pytest.mark.asyncio
+async def test_wrong_audience_is_401(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    document = jwks_document(KEY)
+    _install(monkeypatch, FakeJwksEndpoint(responses=[lambda: document]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL,
+            headers={
+                "Authorization": f"Bearer {KEY.token(audience='https://somewhere.else')}"
+            },
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid claims"}
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_is_401(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    document = jwks_document(KEY)
+    _install(monkeypatch, FakeJwksEndpoint(responses=[lambda: document]), FakeClock())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL,
+            headers={
+                "Authorization": f"Bearer {KEY.token(issuer='https://evil.example.com/')}"
+            },
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid claims"}
+
+@pytest.mark.asyncio
+async def test_unknown_signing_key_is_401(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A token signed by a key the tenant does not publish, even after a refresh."""
+    other = make_key("kid-not-published")
+    document = jwks_document(KEY)
+    _install(monkeypatch, FakeJwksEndpoint(responses=[lambda:document]), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL,
+            headers={"Authorization": f"Bearer {other.token()}"}
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unknown signing key"}
+
+# --------------------------------------------------------------------------
+# The negative assertion the whole P0 is about
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [connect_error],
+        [lambda: {"error": "not a jwks"}],
+        [lambda: {"keys": "not-a-list"}],
+        [lambda: {"keys": [{"kid": "kid-http"}]}],
+        [lambda: {"keys": []}],
+    ],
+    ids=["unreachable", "not-a-jwks", "keys-not-a-list", "incomplete-key", "empty-keys"],
+)
+
+async def test_no_jwks_failure_mode_produces_a_500(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch, responses: list[Callable[[], Any]]
+) -> None:
+    """
+    Five ways the JWKS endpoint can misbehave; none may produce a 500.
+
+    Each of these was a 500 before the P0 #2 change. The first three are
+    infrastructure faults (503); the last two yield a key set that simply does
+    not contain the token's kid, which is a 401.
+    """
+    _install(monkeypatch, FakeJwksEndpoint(responses=responses), FakeClock())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            PROTECTED_URL,
+            headers={"Authorization": f"Bearer {KEY.token()}"}
+        )
+
+    assert response.status_code != 500
+    assert response.status_code in (401, 503)

--- a/backend/tests/api/test_startup_auth_config.py
+++ b/backend/tests/api/test_startup_auth_config.py
@@ -1,0 +1,202 @@
+"""
+Startup-gate behaviour: a pod may not start with a half-configured Auth0 setup.
+
+Two layers:
+  * Auth0Settings.configuration_errors() -- pure, exhaustive, fast.
+  * _validate_auth0_configuration() and lifespan -- the actual gate.
+
+Note that httpx's ASGITransport does not run the ASGI lifespan protocol, so
+the rest of the suite never executes `lifespan`; these tests drive it directly.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from biosim_server.api.main import _validate_auth0_configuration, app, lifespan
+from biosim_server.config import Auth0Settings, get_settings
+
+
+# --------------------------------------------------------------------------
+# Auth0Settings.configuration_errors()
+# --------------------------------------------------------------------------
+
+def _settings(**overrides: object) -> Auth0Settings:
+    """
+    Build an Auth0Settings without reading the ambient environment.
+
+    _env_file=None keeps a developer's backend/.env (which does set
+    AUTH0_DOMAIN) from making these tests pass for the wrong reason.
+    """
+
+    base: dict[str, object] = {
+        "AUTH0_DOMAIN": "tenant.us.auth0.com",
+        "AUTH0_AUDIENCE": "https://api.example.test",
+        "AUTH0_ISSUER": "",
+        "AUTH0_JWKS_URI": "",
+    }
+    base.update(overrides)
+    return Auth0Settings(_env_file=None, **base) # type: ignore[call-arg,arg-type]
+
+def test_complete_configuration_has_no_errors() -> None:
+    assert _settings().configuration_errors() == []
+
+def test_explicit_issuer_jwks_overrides_are_accepted() -> None:
+    """The shape tests/fixtures/keycloak uses: no domain, both overrides set."""
+    errors = _settings(
+        AUTH0_DOMAIN="",
+        AUTH0_ISSUER="http://localhost:8080/realms/biosim-test",
+        AUTH0_JWKS_URI="http://localhost:8080/realms/biosim-test/protocol/openid-connect/certs",
+    ).configuration_errors()
+    assert errors == []
+
+def test_missing_domain_is_reported() -> None:
+    errors = _settings(AUTH0_DOMAIN="").configuration_errors()
+    assert any("AUTH0_DOMAIN" in e for e in errors)
+
+def test_missing_audience_is_reported() -> None:
+    errors = _settings(AUTH0_AUDIENCE="").configuration_errors()
+    assert errors == ["AUTH0_AUDIENCE is not set"]
+
+def test_empty_configuration_reports_every_problem_at_once() -> None:
+    """
+    An operator must be able to fix everything in one edit, not one per restart.
+    """
+    errors = _settings(AUTH0_DOMAIN="", AUTH0_AUDIENCE="").configuration_errors()
+    assert len(errors) >= 3
+    assert any("AUTH0_AUDIENCE" in e for e in errors)
+    assert any("AUTH0_ISSUER" in e for e in errors)
+    assert any("AUTH0_JWKS_URI" in e for e in errors)
+
+def test_half_configured_override_is_reported() -> None:
+    """AUTH0_ISSUER without AUTH0_JWKS_URI is not a valid configuration."""
+    errors = _settings(
+        AUTH0_DOMAIN="", AUTH0_ISSUER="https://issuer.example.test/"
+    ).configuration_errors()
+    assert any("AUTH0_JWKS_URI" in e for e in errors)
+    assert not any("AUTH0_ISSUER" in e for e in errors)
+
+@pytest.mark.parametrize(
+    "bad_domain",
+    [
+        "https://tenant.us.auth0.com",
+        "tenant.us.auth0.com/",
+        "https://tenant.us.auth0.com/"
+    ],
+)
+def test_url_shaped_domain_is_rejected(bad_domain: str) -> None:
+    """The silent killer: a URL here yields an issuer no token can ever match."""
+    errors = _settings(AUTH0_DOMAIN=bad_domain).configuration_errors()
+    assert any("bare hostname" in e for e in errors)
+
+@pytest.mark.parametrize("bad_domain", ["tenant", " tenant.us.auth0.com"])
+def test_malformed_hostname_is_rejected(bad_domain: str) -> None:
+    errors = _settings(AUTH0_DOMAIN=bad_domain).configuration_errors()
+    assert any("does not look like a hostname" in e for e in errors)
+
+def test_empty_algorithm_allowlist_is_reported() -> None:
+    errors = _settings(algorithms=[]).configuration_errors()
+    assert any("algorithm allowlist" in e for e in errors)
+
+# --------------------------------------------------------------------------
+# The gate itself
+# --------------------------------------------------------------------------
+
+def test_gate_passes_with_valid_configuration(
+        monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A complete configuration starts and records what it validated."""
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "required", True)
+    monkeypatch.setattr(settings, "domain", "tenant.us.auth0.com")
+    monkeypatch.setattr(settings, "audience", "https://api.example.test")
+    monkeypatch.setattr(settings, "issuer", "")
+    monkeypatch.setattr(settings, "jwks_uri", "")
+
+    with caplog.at_level("INFO"):
+        _validate_auth0_configuration()
+    assert "Auth0 configuration validated" in caplog.text
+
+def test_gate_raises_when_required_and_misconfigured(
+        monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The P0 #5 core assertion: no half-configured cluster may start."""
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "required", True)
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "audience", "")
+    monkeypatch.setattr(settings, "issuer", "")
+    monkeypatch.setattr(settings, "jwks_uri", "")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _validate_auth0_configuration()
+
+    message = str(exc_info.value)
+    assert "refusing to start" in message
+    assert "AUTH0_AUDIENCE" in message
+    assert "AUTH0_DOMAIN" in message
+    assert "AUTH_REQUIRED=false" in message
+
+
+def test_gate_warns_but_starts_when_auth_is_deliberately_disabled(
+        monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AUTH_REQUIRED=false starts, and the warning states the real failure mode."""
+
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "required", False)
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "audience", "")
+    monkeypatch.setattr(settings, "issuer", "")
+    monkeypatch.setattr(settings, "jwks_uri", "")
+
+    with caplog.at_level("WARNING"):
+        _validate_auth0_configuration()     # must not raise
+
+    assert "AUTH_REQUIRED=false" in caplog.text
+    assert "503" in caplog.text
+
+    assert  "401" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_lifespan_validates_before_opening_connections(
+        monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configuration error aborts startup before Mongo/Temporal are touched."""
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "required", True)
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "audience", "")
+    monkeypatch.setattr(settings, "issuer", "")
+    monkeypatch.setattr(settings, "jwks_uri", "")
+
+    with patch("biosim_server.api.main.init_standalone", new=AsyncMock()) as init_mock:
+        with pytest.raises(RuntimeError):
+            async with lifespan(app):
+                pass # pragma: no cover -- startup must abort before this runs
+
+    init_mock.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_lifespan_proceeds_with_valid_configuration(
+        monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The happy path still initialises and shuts down the service singletons."""
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "required", True)
+    monkeypatch.setattr(settings, "domain", "tenant.us.auth0.com")
+    monkeypatch.setattr(settings, "audience", "https://api.example.test")
+    monkeypatch.setattr(settings, "issuer", "")
+    monkeypatch.setattr(settings, "jwks_uri", "")
+
+    with patch("biosim_server.api.main.init_standalone", new=AsyncMock()) as init_mock:
+        with patch(
+            "biosim_server.api.main.shutdown_standalone", new=AsyncMock()
+        ) as shutdown_mock:
+            async with lifespan(app):
+                init_mock.assert_awaited_once()
+    shutdown_mock.assert_awaited_once()
+
+
+

--- a/backend/tests/common/test_auth0_jwks.py
+++ b/backend/tests/common/test_auth0_jwks.py
@@ -1,0 +1,359 @@
+"""
+JWKS cache behaviour: freshness, negative caching, staleness bounds, and
+rotation recovery in common/auth/auth0.py.
+
+These are hermetic unit tests -- local RSA keys, a fake JWKS endpoint, and a
+fake clock -- so they carry no marker and run in the default CI invocation
+(`uv run python -m pytest`, .github/workflows/ci.yaml:26). The live-IdP
+counterparts live in tests/common/test_auth0.py and
+tests/rbac_demo/test_keycloak_integration.py.
+"""
+
+import asyncio
+from typing import Any, Iterator
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from biosim_server.common.auth import auth0 as auth0_module
+from biosim_server.common.auth.auth0 import get_current_user, get_optional_user
+from biosim_server.config import get_settings
+from tests.fixtures.jwks_fixtures import (
+    AUDIENCE,
+    ISSUER,
+    FakeClock,
+    FakeJwksEndpoint,
+    connect_error,
+    http_500,
+    jwks_document,
+    make_key,
+)
+
+KEY_A = make_key("key-a")
+KEY_B = make_key("key-b")
+
+@pytest.fixture(autouse=True)
+def _clean_jwks_cache() -> Iterator[None]:
+    """Every test starts with an empty cache, no armed backoff, no cooldown."""
+    auth0_module._reset_jwks_cache()
+    yield
+    auth0_module._reset_jwks_cache()
+
+@pytest.fixture
+def auth_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Points the token verifier at the local test issuer/audience.
+
+    Mirrors tests/fixtures/keycloak/client.py: get_settings() is lru_cache'd,
+    so there is no injection seam and the singleton's fields are monkeypatched
+    in place (reverted at teardown).
+    """
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "issuer", ISSUER)
+    monkeypatch.setattr(settings, "jwks_uri", "https://idp.invalid/.well-known/jwks.json")
+    monkeypatch.setattr(settings, "audience", AUDIENCE)
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, endpoint: FakeJwksEndpoint, clock: FakeClock
+) -> None:
+    monkeypatch.setattr(
+        auth0_module.httpx,  # type: ignore[attr-defined]
+        "AsyncClient",
+        endpoint.client_factory(),
+    )
+    monkeypatch.setattr(auth0_module, "time", clock)
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+def _ok(*keys: Any) -> Any:
+    document = jwks_document(*keys)
+    return lambda: document
+
+# --------------------------------------------------------------------------
+# Happy path and caching
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_successful_fetch_validates_token(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Baseline: a reachable JWKS endpoint verifies a correctly signed token."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    user = await get_current_user(_creds(KEY_A.token(sub="auth0|alice")))
+
+    assert user.sub == "auth0|alice"
+    assert endpoint.call_count == 1
+
+@pytest.mark.asyncio
+async def test_cached_keys_are_reused_within_the_ttl(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated requests inside the TTL must not re-fetch."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    for _ in range(5):
+        await get_current_user(_creds(KEY_A.token()))
+        clock.advance(60)
+
+    assert endpoint.call_count == 1
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_makes_exactly_one_fetch(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    N concurrent first requests collapse to a single outbound JWKS fetch.
+
+    This is the thundering-herd guard (TODO #12), which is why the refresh lock
+    ships with this change rather than after it.
+    """
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    tokens = [_creds(KEY_A.token()) for _ in range(25)]
+    users = await asyncio.gather(*(get_current_user(c) for c in tokens))
+
+    assert len(users) == 25
+    assert endpoint.call_count == 1
+
+# --------------------------------------------------------------------------
+# Failure handling: 503, Retry-After, never 500
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [connect_error, http_500])
+async def test_idp_failure_with_empty_cache_returns_503_with_retry_after(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch, failure: Any
+) -> None:
+    """Cold cache + unreachable IdP => 503 with Retry-After, never a 500.
+
+    Parametrised over a transport error and an HTTP error status because the
+    original code handled neither and both produced a 500.
+    """
+    endpoint = FakeJwksEndpoint(responses=[failure])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(KEY_A.token()))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.headers is not None
+    assert exc_info.value.headers["Retry-After"] == "10"
+    assert exc_info.value.detail == "Authentication temporarily unavailable"
+
+@pytest.mark.asyncio
+async def test_malformed_jwks_body_is_a_failure_not_a_poisoned_cache(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200 response that is not a JWKS document must never be cached."""
+    endpoint = FakeJwksEndpoint(responses=[lambda: {"error": "not a jwks"}])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(KEY_A.token()))
+
+    assert exc_info.value.status_code == 503
+    assert auth0_module._jwks_cache["keys"] is None
+
+@pytest.mark.asyncio
+async def test_failing_idp_is_probed_at_most_once_per_backoff_window(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The negative cache: 50 requests during an outage produce 1 outbound call."""
+    endpoint = FakeJwksEndpoint(responses=[connect_error])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    for _ in range(50):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(_creds(KEY_A.token()))
+        assert exc_info.value.status_code == 503
+        clock.advance(0.1)  # 5 s total, inside the 10 s window
+
+    assert endpoint.call_count == 1
+
+@pytest.mark.asyncio
+async def test_backoff_expires_and_the_idp_recovers(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After the backoff window the next request retries and recovery is immediate."""
+    endpoint = FakeJwksEndpoint(responses=[connect_error, _ok(KEY_A)])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    with pytest.raises(HTTPException):
+        await get_current_user(_creds(KEY_A.token()))
+    assert endpoint.call_count == 1
+
+    clock.advance(11)  # past _JWKS_FAILURE_BACKOFF_SECONDS
+    user = await get_current_user(_creds(KEY_A.token()))
+
+    assert user.sub == "auth0|test-user"
+    assert endpoint.call_count == 2
+
+# --------------------------------------------------------------------------
+# Stale-while-revalidate
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stale_keys_are_served_when_refresh_fails(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A populated cache plus an unreachable IdP still validates tokens -- and warns."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A), connect_error])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(KEY_A.token()))     # populate
+    clock.advance(3601)                               # expire the TTL
+
+    with caplog.at_level("WARNING"):
+        user = await get_current_user(_creds(KEY_A.token()))
+
+    assert user.sub == "auth0|test-user"
+    assert "Serving stale JWKS" in caplog.text
+
+@pytest.mark.asyncio
+async def test_keys_past_the_staleness_bound_are_refused(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Staleness is bounded: a day-old key set is no longer served."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A), connect_error])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(KEY_A.token()))
+    clock.advance(86_401)  # past _JWKS_STALE_MAX_AGE_SECONDS
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(KEY_A.token()))
+
+    assert exc_info.value.status_code == 503
+
+# --------------------------------------------------------------------------
+# Rotation: unknown kid
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unknown_kid_forces_one_refresh_and_recovers(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Key rotation self-heals without waiting out the 3600 s TTL.
+
+    The cache is populated with KEY_A only; the token is signed with KEY_B,
+    which the IdP publishes on the next fetch. The original implementation
+    returned 401 here for up to an hour.
+    """
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A), _ok(KEY_A, KEY_B)])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(KEY_A.token()))     # populate with KEY_A only
+    user = await get_current_user(_creds(KEY_B.token(sub="auth0|rotated")))
+
+    assert user.sub == "auth0|rotated"
+    assert endpoint.call_count == 2
+
+@pytest.mark.asyncio
+async def test_unknown_kid_flood_is_cooldown_limited(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Tokens with bogus kids must not become an amplification vector.
+
+    30 requests inside the 60 s cooldown produce exactly one forced refresh
+    on top of the initial population fetch.
+    """
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(KEY_A.token()))
+    assert endpoint.call_count == 1
+
+    for _ in range(30):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(_creds(KEY_B.token()))
+        assert exc_info.value.status_code == 401
+        clock.advance(1)  # 30 s total, inside the 60 s cooldown
+
+    assert endpoint.call_count == 2
+
+@pytest.mark.asyncio
+async def test_unknown_kid_still_unknown_after_refresh_is_401(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refresh that does not produce the kid keeps the original 401."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    await get_current_user(_creds(KEY_A.token()))
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(KEY_B.token()))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Unknown signing key"
+
+@pytest.mark.asyncio
+async def test_unknown_kid_during_an_outage_does_not_bypass_the_backoff(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The forced refresh respects the negative cache.
+
+    Otherwise an unknown-kid flood during an IdP outage would defeat the very
+    backoff that outage armed.
+    """
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A), connect_error])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(KEY_A.token()))
+    clock.advance(3601)
+    with pytest.raises(HTTPException):          # TTL refresh fails, arms backoff
+        await get_current_user(_creds(KEY_B.token()))
+    calls_after_outage = endpoint.call_count
+
+    for _ in range(10):
+        with pytest.raises(HTTPException):
+            await get_current_user(_creds(KEY_B.token()))
+        clock.advance(0.1)
+
+    assert endpoint.call_count == calls_after_outage
+
+# --------------------------------------------------------------------------
+# get_optional_user
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_optional_user_propagates_503_but_swallows_401(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An IdP outage must not silently downgrade a token-bearing caller to anonymous."""
+    endpoint = FakeJwksEndpoint(responses=[connect_error])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_optional_user(_creds(KEY_A.token()))
+    assert exc_info.value.status_code == 503
+
+    # A caller with no token at all is unaffected -- and never touches the IdP.
+    assert await get_optional_user(None) is None
+
+@pytest.mark.asyncio
+async def test_optional_user_returns_none_for_a_bad_token(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """401-class faults keep degrading to anonymous, exactly as before."""
+    endpoint = FakeJwksEndpoint(responses=[_ok(KEY_A)])
+    _install(monkeypatch, endpoint, FakeClock())
+
+    assert await get_optional_user(_creds("not-a-jwt")) is None

--- a/backend/tests/common/test_auth0_reliability.py
+++ b/backend/tests/common/test_auth0_reliability.py
@@ -1,0 +1,282 @@
+"""
+Multi-phase reliability scenarios for the JWKS cache.
+
+tests/common/test_auth0_jwks.py pins individual behaviours -- backoff, stale
+service, cooldown -- one at a time. This module runs them as timelines: a
+sustained outage with recovery, a rotation during an outage, a cold start
+during an outage. Those interactions are where cache state machines actually
+break, and they are exactly what happens during a real incident.
+
+Hermetic: local RSA keys, a fake JWKS endpoint, a fake clock. No container, no
+network, no sleeping.
+"""
+
+
+import asyncio
+from typing import Any, Iterator
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from biosim_server.common.auth import auth0 as auth0_module
+from biosim_server.common.auth.auth0 import get_current_user
+from biosim_server.config import get_settings
+from tests.fixtures.jwks_fixtures import (
+    AUDIENCE,
+    ISSUER,
+    FakeClock,
+    FakeJwksEndpoint,
+    connect_error,
+    jwks_document,
+    make_key,
+)
+
+OLD_KEY = make_key("kid-old")
+NEW_KEY = make_key("kid-new")
+
+@pytest.fixture(autouse=True)
+def _clean() -> Iterator[None]:
+    auth0_module._reset_jwks_cache()
+    yield
+    auth0_module._reset_jwks_cache()
+
+@pytest.fixture
+def auth_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "issuer", ISSUER)
+    monkeypatch.setattr(settings, "jwks_uri", "https://idp.invalid/.well-known/jwks.json")
+    monkeypatch.setattr(settings, "audience", AUDIENCE)
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, endpoint: FakeJwksEndpoint, clock: FakeClock
+) -> None:
+    monkeypatch.setattr(
+        auth0_module.httpx,  # type: ignore[attr-defined]
+        "AsyncClient",
+        endpoint.client_factory(),
+    )
+    monkeypatch.setattr(auth0_module, "time", clock)
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+class Scripted:
+    """
+    A JWKS endpoint whose behaviour is flipped mid-test.
+
+    Models a real incident better than a fixed response queue: the endpoint is
+    up, then down, then up again, while requests keep arriving throughout.
+    """
+
+    def __init__(self, document: dict[str, Any]) -> None:
+        self.document = document
+        self.up = True
+
+    def __call__(self) -> dict[str, Any]:
+        if not self.up:
+            return connect_error()
+        return self.document
+
+@pytest.mark.asyncio
+async def test_sustained_outage_then_recovery(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A 20-minute Auth0 outage, minute by minute.
+
+    Phase 1  warm cache, IdP up          -> 200, 1 fetch
+    Phase 2  IdP down, cache still fresh -> 200, 0 fetches (never even asked)
+    Phase 3  IdP down, TTL expired       -> 200 from stale keys, 1 fetch per 10 s
+    Phase 4  IdP back up                 -> 200, cache refreshed, backoff cleared
+    """
+
+    script = Scripted(jwks_document(OLD_KEY))
+
+    endpoint = FakeJwksEndpoint(responses=[script])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    # Phase 1: warm cache, IdP up -> 200, 1 fetch
+    await get_current_user(_creds(OLD_KEY.token()))
+
+    assert endpoint.call_count == 1
+
+    # Phase 2: IdP down, cache still fresh -> 200, 0 fetches (never even asked)
+    script.up = False
+    for _ in range(30):
+        await get_current_user(_creds(OLD_KEY.token()))
+
+        clock.advance(60)
+
+    fetches_after_phase_2 = endpoint.call_count
+
+    # Phase 3: IdP down, TTL expired -> 200 from stale keys, 1 fetch per 10 s
+    for _ in range(20):
+        user = await get_current_user(_creds(OLD_KEY.token()))
+
+        assert user.sub == "auth0|test-user"
+
+        # Stale keys still verify
+        clock.advance(1)
+
+    assert endpoint.call_count <= fetches_after_phase_2 + 3
+
+    # Phase 4: IdP back up -> 200, cache refreshed, backoff cleared
+    script.up = True
+    clock.advance(11)
+    await get_current_user(_creds(OLD_KEY.token()))
+
+    assert auth0_module._jwks_cache["last_failure_at"] == 0.0
+
+    # Backoff cleared and the cache is fresh again: no further fetches for a while
+
+    before = endpoint.call_count
+
+    for _ in range(10):
+        await get_current_user(_creds(OLD_KEY.token()))
+
+        clock.advance(60)
+
+    assert endpoint.call_count == before
+
+@pytest.mark.asyncio
+async def test_outbound_rate_is_bounded_regardless_of_inbound_load(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    1000 requests over a simulated 60 s outage must not produce 1000 fetches.
+
+    The ceiling is 60 s / 10 s backoff = 6 attempts, plus the initial one.
+    """
+    endpoint = FakeJwksEndpoint(responses=[connect_error])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    for _ in range(1000):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(_creds(OLD_KEY.token()))
+        assert exc_info.value.status_code == 503
+        clock.advance(0.06)
+
+    assert endpoint.call_count <= 7
+
+@pytest.mark.asyncio
+async def test_rotation_during_an_outage_recovers_when_the_idp_returns(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The worst realistic case: Auth0 rotates keys *while* it is unreachable.
+
+    Old-key tokens keep working from the stale cache. New-key tokens 401 --
+    correctly, since the backend has no way to learn the new key -- and start
+    working as soon as the IdP is reachable again.
+    """
+
+    script = Scripted(jwks_document(OLD_KEY))
+    endpoint = FakeJwksEndpoint(responses=[script])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(OLD_KEY.token()))
+
+    # auth0 goes down and rotates while down
+    script.up = False
+    script.document = jwks_document(NEW_KEY)
+    clock.advance(3601)
+
+    # Old tokens still verify from the stale cache
+    assert (await get_current_user(_creds(OLD_KEY.token()))).sub == "auth0|test-user"
+
+    # New-key tokens cannot verify -- 401, never 500, never a hang
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(NEW_KEY.token()))
+    assert exc_info.value.status_code == 401
+
+    # Auth0 returns. Past both the backoff and the kid cooldown
+    script.up = True
+    clock.advance(61)
+    user = await get_current_user(_creds(NEW_KEY.token(sub="auth0|new")))
+    assert user.sub == "auth0|new"
+
+@pytest.mark.asyncio
+async def test_cold_start_during_an_outage_fails_closed_then_recovers(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A pod that restarts mid-outage has no stale keys to fall back on.
+
+    503 is the correct answer, and recovery must be automatic -- no restart, no
+    intervention -- once the IdP is reachable.
+    """
+
+    script = Scripted(jwks_document(OLD_KEY))
+    script.up = False
+    endpoint = FakeJwksEndpoint(responses=[script])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(OLD_KEY.token()))
+    assert exc_info.value.status_code == 503
+
+    script.up = True
+    clock.advance(11)
+
+    assert (await get_current_user(_creds(OLD_KEY.token()))).sub == "auth0|test-user"
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_during_recovery_produce_one_fetch(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The recovery moment is the thundering-herd moment.
+
+    Every waiting request wakes at once when the backoff expires; the lock plus
+    the double check must collapse them into a single fetch.
+    """
+
+    script = Scripted(jwks_document(OLD_KEY))
+    script.up = False
+    endpoint = FakeJwksEndpoint(responses=[script])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    with pytest.raises(HTTPException):
+        await get_current_user(_creds(OLD_KEY.token()))
+    fetches_during_outrage = endpoint.call_count
+
+    script.up = True
+    clock.advance(11)
+
+    results = await asyncio.gather(
+        *(get_current_user(_creds(OLD_KEY.token())) for _ in range(50))
+    )
+
+    assert len(results) == 50
+    assert endpoint.call_count == fetches_during_outrage + 1
+
+@pytest.mark.asyncio
+async def test_staleness_bound_is_enforced_and_recovery_still_works_after_it(
+    auth_settings: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Past 24 h the cache stops being served -- but the system is not wedged."""
+
+    script = Scripted(jwks_document(OLD_KEY))
+    endpoint = FakeJwksEndpoint(responses=[script])
+    clock = FakeClock()
+    _install(monkeypatch, endpoint, clock)
+
+    await get_current_user(_creds(OLD_KEY.token()))
+    script.up = False
+    clock.advance(86_401)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(_creds(OLD_KEY.token()))
+    assert exc_info.value.status_code == 503
+
+    script.up = True
+    clock.advance(11)
+
+    assert (await get_current_user(_creds(OLD_KEY.token()))).sub == "auth0|test-user"

--- a/backend/tests/common/test_auth0_roles_claim.py
+++ b/backend/tests/common/test_auth0_roles_claim.py
@@ -1,0 +1,128 @@
+"""
+The Post-Login Action runtime assertion (P0 #4).
+
+The Auth0 Action that stamps the roles claim lives in auth0/actions/post-login.js
+and is deployed by hand in the Auth0 dashboard. When it is missing, disabled,
+or bound to no flow, every require_roles endpoint 403s silently. These tests
+pin the WARNING that makes that state visible, and pin that it changes no
+authorization outcome.
+
+Hermetic: local RSA keys and a fake JWKS endpoint from tests/fixtures/jwks_fixtures.py,
+no container, no network.
+"""
+
+from typing import Iterator
+
+import pytest
+
+from biosim_server.common.auth import auth0 as auth0_module
+from biosim_server.common.auth.auth0 import get_current_user
+from biosim_server.config import get_settings
+from tests.fixtures.jwks_fixtures import (
+    AUDIENCE,
+    ISSUER,
+    FakeClock,
+    FakeJwksEndpoint,
+    jwks_document,
+    make_key,
+)
+
+ROLES_CLAIM = "https://api.biosimulations.org/roles"
+KEY = make_key("kid-roles")
+
+@pytest.fixture(autouse=True)
+def _clean_state() -> Iterator[None]:
+    auth0_module._reset_jwks_cache()
+    yield
+    auth0_module._reset_jwks_cache()
+
+@pytest.fixture
+def verifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Points token verification at a local key set and the default roles claim."""
+    settings = get_settings().auth0
+    monkeypatch.setattr(settings, "domain", "")
+    monkeypatch.setattr(settings, "issuer", ISSUER)
+    monkeypatch.setattr(settings, "jwks_uri", "https://idp.invalid/.well-known/jwks.json")
+    monkeypatch.setattr(settings, "audience", AUDIENCE)
+    monkeypatch.setattr(settings, "roles_claim", ROLES_CLAIM)
+
+    document = jwks_document(KEY)
+    endpoint = FakeJwksEndpoint(responses=[lambda: document])
+    monkeypatch.setattr(auth0_module.httpx, "AsyncClient", endpoint.client_factory())
+    monkeypatch.setattr(auth0_module, "time", FakeClock())
+
+def _creds(token: str) -> object:
+    from fastapi.security import HTTPAuthorizationCredentials
+    return HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=token
+    )
+
+@pytest.mark.asyncio
+async def test_roles_claim_present_produces_no_warning(
+    verifier: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The healthy case must be silent -- a warning that fires normally is noise."""
+
+    token = KEY.token(extra_claims={ROLES_CLAIM: ["admin"]})
+
+    with caplog.at_level("WARNING"):
+        user = await get_current_user(_creds(token))
+
+    assert user.roles == ["admin"]
+    assert "roles claims" not in caplog.text.lower()
+
+@pytest.mark.asyncio
+async def test_missing_roles_claim_names_the_action(
+    verifier: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No claim at all == the Action is not deployed. Say so."""
+    token = KEY.token()
+
+    with caplog.at_level("WARNING"):
+        user = await get_current_user(_creds(token))
+
+    assert user.roles == []
+    assert "Post-Login Action" in caplog.text
+    assert ROLES_CLAIM in caplog.text
+    assert user.sub not in caplog.text
+
+@pytest.mark.asyncio
+async def test_empty_roles_claim_names_role_assignment(
+    verifier: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty list means the Action ran but the user has no roles -- a different fix."""
+
+    token = KEY.token(extra_claims={ROLES_CLAIM: []})
+    with caplog.at_level("WARNING"):
+        user = await get_current_user(_creds(token))
+
+    assert user.roles == []
+    assert "no roles assigned" in caplog.text
+    assert "Post-Login Action" not in caplog.text
+
+@pytest.mark.asyncio
+async def test_malformed_roles_claim_is_coerced_and_warning(
+    verifier: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-list claim (a string, an object) must not crash and must not authorize."""
+    token = KEY.token(extra_claims={ROLES_CLAIM: "admin"})
+
+    with caplog.at_level("WARNING"):
+        user = await get_current_user(_creds(token))
+
+    assert user.roles == []
+    assert "not a list" in caplog.text
+
+@pytest.mark.asyncio
+async def test_warning_is_rated_limited(
+    verifier: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A tenant with no Action must produce a signal, not one line per request."""
+    token = KEY.token()
+
+    with caplog.at_level("WARNING"):
+        for _ in range(20):
+            await get_current_user(_creds(token))
+
+    assert caplog.text.count("Post-Login Action") == 1
+

--- a/backend/tests/fixtures/jwks_fixtures.py
+++ b/backend/tests/fixtures/jwks_fixtures.py
@@ -1,0 +1,154 @@
+"""
+Local RSA keys, JWKS documents, and a fake httpx client for JWKS-path tests.
+
+Lets tests exercise common/auth/auth0.py's JWKS caching, backoff, and rotation
+logic without a container and without network access -- complementing (not
+replacing) the live-Keycloak tests in tests/common/test_auth0.py and
+tests/rbac_demo/test_keycloak_integration.py, which stay the source of truth
+for real end-to-end verification.
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import httpx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import jwk, jwt  # type: ignore[import-untyped]
+
+ISSUER = "https://test-tenant.auth0.com/"
+AUDIENCE = "https://api.example.com/"
+
+@dataclass(frozen=True)
+class TestKey:
+    """An RSA keypair plus the JWKS entry and tokens derived from it."""
+
+    kid: str
+    private_pem: str
+    jwk_entry: dict[str, str]
+
+    def token(
+        self,
+        *,
+        sub: str = "auth0|test-user",
+        issuer: str = ISSUER,
+        audience: str = AUDIENCE,
+        expires_in: int = 3600,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> str:
+        claims: dict[str, Any] = {
+            "sub": sub,
+            "iss": issuer,
+            "aud": audience,
+            "iat": int(time.time()),
+            "exp": int(time.time()) + expires_in,
+        }
+        if extra_claims:
+            claims.update(extra_claims)
+        return str(
+            jwt.encode(claims, self.private_pem, algorithm="RS256", headers={"kid": self.kid})
+        )
+
+def make_key(kid: str) -> TestKey:
+    """
+    Generate a 2048-bit RSA key and its RFC 7517 public JWK entry.
+
+    python-jose's public_key().to_dict() returns only alg/kty/n/e -- no `kid`
+    and no `use` -- which is exactly why _select_rsa_key must tolerate a
+    missing `use` rather than indexing it.
+    """
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_jwk = jwk.construct(private_pem, algorithm="RS256").public_key().to_dict()
+    entry = {
+        "kty": str(public_jwk["kty"]),
+        "kid": kid,
+        "alg": "RS256",
+        "n": str(public_jwk["n"]),
+        "e": str(public_jwk["e"]),
+    }
+    return TestKey(kid=kid, private_pem=private_pem, jwk_entry=entry)
+
+def jwks_document(*keys: TestKey) -> dict[str, Any]:
+    """Assemble a JWKS document from the given keys."""
+    return {"keys": [k.jwk_entry for k in keys]}
+
+class FakeClock:
+    """
+    Controllable stand-in for the `time` module inside auth0.py.
+
+    auth0.py calls the module-global name `time`, so
+    `monkeypatch.setattr(auth0_module, "time", FakeClock())` swaps the clock
+    for that module alone -- no global time patching, no sleeping in tests.
+    """
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+@dataclass
+class FakeJwksEndpoint:
+    """
+    Scripted replacement for httpx.AsyncClient inside _fetch_jwks_locked.
+
+    `responses` is a queue of callables; each call to .get() pops the next one
+    (the last is reused once exhausted, so a steady state can be expressed with
+    a single entry). A callable may return a JWKS document or raise.
+    """
+    responses: list[Callable[[], dict[str, Any]]]
+    calls: list[str] = field(default_factory=list)
+
+    def client_factory(self) -> Callable[..., "FakeJwksEndpoint"]:
+        """Return something usable as 'httpx.AsyncClient' itself."""
+
+        def _factory(*_args: Any, **_kwargs: Any) -> "FakeJwksEndpoint":
+            return self
+
+        return _factory
+
+    async def __aenter__(self) -> "FakeJwksEndpoint":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def get(self, url: str, timeout: float | None = None) -> "FakeJwksResponse":
+        self.calls.append(url)
+        produce = self.responses[0] if len(self.responses) == 1 else self.responses.pop(0)
+        return FakeJwksResponse(produce())
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
+@dataclass
+class FakeJwksResponse:
+    payload: dict[str, Any]
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+def connect_error() -> dict[str, Any]:
+    """A 'responses' entry that simulates the idP being unreachable."""
+    raise httpx.ConnectError("simulated idP outage")
+
+def http_500() -> dict[str, Any]:
+    """A 'responses' entry that simulates the idP returning 5xx."""
+    raise httpx.HTTPStatusError(
+        "simulated 500",
+        request=httpx.Request("GET", "https://idp.invalid/.well-known/jwks.json"),
+        response=httpx.Response(500),
+    )

--- a/backend/tests/fixtures/keycloak/client.py
+++ b/backend/tests/fixtures/keycloak/client.py
@@ -22,8 +22,10 @@ def keycloak_auth_settings(keycloak_realm: KeycloakTestRealm, monkeypatch: pytes
     get_settings() is lru_cache'd, so there's no dependency-injection seam to
     swap in test config -- this mutates the live Auth0Settings singleton's
     fields in place; monkeypatch reverts each one automatically at teardown.
-    Also resets the module-level JWKS cache in auth0.py so a previously
-    fetched (Auth0 or prior-test-Keycloak) key set can't leak into this test.
+    Also resets the module-level JWKS cache in auth0.py -- including its
+    backoff and cooldown state -- so a previously fetched (Auth0 or
+    prior-test-Keycloak) key set, or an armed negative cache, can't leak into
+    this test.
     """
     settings = get_settings().auth0
     monkeypatch.setattr(settings, "domain", "")
@@ -31,8 +33,7 @@ def keycloak_auth_settings(keycloak_realm: KeycloakTestRealm, monkeypatch: pytes
     monkeypatch.setattr(settings, "jwks_uri", keycloak_realm.jwks_uri)
     monkeypatch.setattr(settings, "audience", keycloak_realm.audience)
     monkeypatch.setattr(settings, "roles_claim", keycloak_realm.roles_claim)
-    auth0_module._jwks_cache["keys"] = None
-    auth0_module._jwks_cache["fetched_at"] = 0.0
+    auth0_module._reset_jwks_cache()
     return keycloak_realm
 
 

--- a/kustomize/config/biosim-local/api.env
+++ b/kustomize/config/biosim-local/api.env
@@ -1,0 +1,3 @@
+AUTH0_DOMAIN=dev-bu7yo7484tyxu6a1.us.auth0.com
+AUTH0_AUDIENCE=https://api.biosimulations.org
+

--- a/kustomize/config/biosim-rke/api.env
+++ b/kustomize/config/biosim-rke/api.env
@@ -6,3 +6,6 @@
 # backend for the WIP-preview frontend at biosim-dev.cam.uchc.edu (from the
 # biosim-rke-frontend-dev overlay), so both origins go here.
 CORS_EXTRA_ORIGINS=https://biosim.cam.uchc.edu,https://biosim-dev.cam.uchc.edu
+
+AUTH0_DOMAIN=dev-bu7yo7484tyxu6a1.us.auth0.com
+AUTH0_AUDIENCE=https://api.biosimulations.org


### PR DESCRIPTION
## Summary

Auth0 WIP #2 — hardens the authentication path landed in #96 so that an
identity-provider hiccup, a rotated signing key, or a half-configured cluster
each produce a correct and legible outcome instead of a silent one.

**Stacked on #97** (`chore/keycloak-tests`) — this PR's base is that branch, so
the diff here is the four commits on top of it. Merge #97 first; GitHub will
retarget this to `main` automatically.

## What changed

### 1. Startup gate instead of a startup warning (`e799d9a`)

`_warn_if_auth0_misconfigured()` logged a warning and let the pod start, so a
cluster with a missing `AUTH0_DOMAIN`/`AUTH0_AUDIENCE` reported healthy and then
failed every authenticated request. The warning also misdescribed the failure
(it promised a 401, which was never what happened).

- `Auth0Settings.configuration_errors()` (`config.py`) — pure, side-effect-free
  enumeration of every reason the settings could not verify a token. Accepts
  both valid shapes: a bare `AUTH0_DOMAIN`, or explicit `AUTH0_ISSUER` **and**
  `AUTH0_JWKS_URI` overrides (how a non-Auth0 OIDC provider, e.g. the Keycloak
  test realm, is configured). Half of the override pair is reported as an error.
- `_validate_auth0_configuration()` (`api/main.py`) raises out of `lifespan`, so
  uvicorn exits non-zero and Kubernetes shows `CrashLoopBackOff` with the reason
  in `kubectl logs`.
- New `AUTH_REQUIRED` setting (default `true`) is the escape hatch: set it false
  to run a deployment deliberately without an identity provider — the API then
  starts, logs what is missing, and every authenticated endpoint returns 503.
- `kustomize/config/biosim-{local,rke}/api.env` get `AUTH0_DOMAIN` +
  `AUTH0_AUDIENCE` (biosim-gke already had them from #96), so those overlays do
  not start crash-looping the moment the gate lands.

### 2. JWKS handling: rotation, outages, and malformed key sets (`e3db45b`, `de31e3e`)

`_get_jwks()` previously refetched on every miss, raised on any failure, and
indexed `k["kty"]/["kid"]/["use"]/["n"]/["e"]` directly — an entry missing the
RFC 7517-optional `use` field raised `KeyError` → HTTP 500.

- **Unknown `kid` forces one refresh** (cooldown-guarded, 60s) before rejecting
  the token. Auth0 rotates signing keys without notice; this turns a rotation
  from an hour-long outage into one slow request. The cooldown is load-bearing:
  without it a flood of bogus `kid`s is an amplification vector against the IdP.
- **Stale-while-revalidate**: a cached document past its 1h TTL is still served
  for up to 24h while refreshes fail, then refused. Well inside Auth0's rotation
  overlap, so a key cached in that window is still a key the tenant published.
- **Negative cache** (10s) after a failed fetch: one outbound request per window
  per process, not one per inbound request.
- **Single-flight refresh** via `asyncio.Lock` with the double-checked pattern
  already used in `auth0_management.py`. The lock is held across the fetch only,
  never across `jwt.decode`, so validation stays parallel.
- `_select_rsa_key()` guards every field access and defaults a missing `use` to
  `"sig"`.

### 3. Error responses and diagnostics (`95c3383`)

- When no usable key set exists, the response is **503 + `Retry-After`**
  ("Authentication temporarily unavailable"), not a 401 — the caller's token was
  never the problem. Detail text names no URL, no exception, no token material.
- **`get_optional_user` no longer swallows the 503.** Downgrading an
  authenticated caller to anonymous during an Auth0 outage silently changes the
  authorization outcome (ownership checks, role gates). 401s stay swallowed —
  a bad token on an optional-auth endpoint is still just "not authenticated".
- The rejected-`kid` log line deliberately does **not** echo the `kid`; it comes
  from an unverified, attacker-controlled header.
- `_warn_roles_claim_absent()` — rate-limited (5 min) runtime assertion that the
  Post-Login Action is live. Without it, an absent Action means every
  `require_roles` endpoint 403s and no admin exists, presenting as a permissions
  bug with no signal anywhere.

### 4. The Auth0 Action is now version-controlled (`e799d9a`)

`auth0/actions/post-login.js` + `auth0/README.md`. #96 depended on a Post-Login
Action that existed only as dashboard state; this is the reviewed source of
truth the dashboard is expected to match. The README documents the required
Roles, the M2M application and its exact scopes (`read:roles`,
`create:role_members` — kept separate from the `update:users`/`delete:users`
application `/api/v1/me` will need), the Action secrets, the `auth0` dependency,
the flow binding, and a post-deploy smoke check. **Nothing in `auth0/` is
deployed by CI or `kubectl`** — applying it is a dashboard action.

Backend `CLAUDE.md` and `.env.example` gain matching Authentication sections.

## Tests

All new, all against real tokens or real HTTP behavior — no mocked JWT
verification:

| File | Covers |
| --- | --- |
| `tests/api/test_startup_auth_config.py` | the startup gate, both `AUTH_REQUIRED` modes, each malformed-config shape |
| `tests/common/test_auth0_jwks.py` | TTL, stale-while-revalidate bound, negative cache, single-flight, malformed key sets |
| `tests/common/test_auth0_reliability.py` | rotation recovery, forced-refresh cooldown, outage behavior |
| `tests/common/test_auth0_roles_claim.py` | roles-claim absent / empty / wrong-type |
| `tests/api/test_auth_error_responses.py` | 401 vs 503 status/headers/detail, `get_optional_user` propagation |
| `tests/fixtures/jwks_fixtures.py` | locally generated RSA key sets for the JWKS tests |

## Review notes

Two things worth a look before merging:

- **`.mcp.json` is committed at the repo root** and points at a machine-local
  PyCharm MCP endpoint (`http://127.0.0.1:64462/stream`). That port is specific
  to one developer's IDE session — it probably belongs in `.gitignore` (as
  `.vscode`/`.cursor` are in this same commit) rather than in the repo.
- **`_warn_if_auth0_misconfigured()` is commented out rather than deleted** —
  wrapped in a `"""` block in `api/main.py`, with the call site left as a
  comment. It is fully replaced by `_validate_auth0_configuration()`; worth
  deleting outright.
