### PR TITLE
Deploy: point biosim-gke at backend-0.10.0 and frontend-0.2.0

### DIFF
--- a/kustomize/overlays/biosim-gke/kustomization.yaml
+++ b/kustomize/overlays/biosim-gke/kustomization.yaml
@@ -5,11 +5,11 @@ namespace: biosim-gke
 
 images:
 - name: ghcr.io/biosimulations/platform-api
-  newTag: backend-0.9.2
+  newTag: backend-0.10.0
 - name: ghcr.io/biosimulations/platform-worker
-  newTag: backend-0.9.2
+  newTag: backend-0.10.0
 - name: ghcr.io/biosimulations/platform-frontend
-  newTag: frontend-0.1.1
+  newTag: frontend-0.2.0
 - name: docker.io/library/mongo
   newTag: 8.0.4
 


### PR DESCRIPTION
## Summary

Points the `biosim-gke` overlay at the images published by
[`backend-v0.10.0`](https://github.com/biosimulations/platform/releases/tag/backend-v0.10.0)
and [`frontend-v0.2.0`](https://github.com/biosimulations/platform/releases/tag/frontend-v0.2.0)
(cut from #99).

**Merging this PR is the deploy.** Flux now reconciles
`kustomize/overlays/biosim-gke`, so the cluster follows `main` within a minute —
no `kubectl apply`.

| Image | From | To |
|---|---|---|
| `platform-api` | `backend-0.9.2` | `backend-0.10.0` |
| `platform-worker` | `backend-0.9.2` | `backend-0.10.0` |
| `platform-frontend` | `frontend-0.1.1` | `frontend-0.2.0` |

## Pre-flight

All three images verified published before opening this: both release runs
completed successfully (api, worker, frontend build jobs all green) and both
GitHub Releases are cut. That check is load-bearing now — `api` uses the
`Recreate` strategy at a single replica, so an unpublished tag here means an
API outage rather than old pods continuing to serve.

## What goes live

Auth0 authentication reaches the cluster for the first time: bearer-token
verification on the backend, owner-or-admin gating on simulation cancel/delete,
and the login / signup / forgot-password UI on the frontend. The `biosim-gke`
ConfigMaps already carry `AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, and the
`NUXT_PUBLIC_AUTH0_*` values, so the configured path works.

Two known gaps, neither blocking:

- `AUTH0_MANAGEMENT_CLIENT_ID` / `_SECRET` are not set in the cluster, so
  `PATCH` / `DELETE /api/v1/me` will fail there. `GET` is unaffected.
- PRs #97 / #98 are not in this release, so the backend has no fail-fast startup
  gate — an incomplete Auth0 config would fail requests rather than crash-loop
  visibly. The config is complete, so this is a diagnosability gap, not a
  functional one.

Also shipping: OMEX `./` manifest fix (#90), simulator versions sorted
newest-first (#91), the frontend QOL batch (#95), and the
`NUXT_PUBLIC_LEGACY_API_URL` fix for project-detail 404s.

## Rollback

Revert this commit. Flux reverts the cluster on the next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
