### PR TITLE
Fix 500 on direct hits to /login, release frontend 0.2.1

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -50,7 +50,14 @@ export default defineNuxtConfig({
   routeRules: {
     '/': { prerender: true },
     '/projects': { redirect: '/biosim-db' },
-    '/runs': { redirect: '/simulations' }
+    '/runs': { redirect: '/simulations' },
+    // Client-only. The Auth0 SDK is installed by plugins/auth0.client.ts, which
+    // cannot run on the server (it reads window.location.origin for the
+    // redirect_uri), so useAuth0() is undefined during SSR and login.vue's
+    // top-level destructure throws a 500. The page is a redirect launcher with
+    // nothing to server-render anyway. Only direct hits and refreshes were
+    // affected -- in-app navigation to /login is client-side and always worked.
+    '/login': { ssr: false }
   },
 
   compatibilityDate: '2025-01-15',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platform-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@auth0/auth0-vue": "^2.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

`https://biosim.biosimulations.org/login` has returned a 500 to every direct
request since `frontend-0.2.0` went live:

```
Cannot destructure property 'loginWithRedirect' of 'useAuth0(...)' as it is undefined.
```

`plugins/auth0.client.ts` installs the Auth0 SDK and is client-only by necessity
— it reads `window.location.origin` to build `redirect_uri`. During SSR that
plugin never runs, so `useAuth0()` is `undefined` and `login.vue:4`'s top-level
destructure throws.

Marks `/login` as `ssr: false` in `routeRules`. The page is a redirect launcher
with nothing to server-render, and the client-only shell hydrates into exactly
the same page. Also bumps frontend to **0.2.1** so the fix can be tagged and
released directly.

## Why it wasn't caught

In-app navigation to `/login` — clicking Log In in the header — is client-side
routing, which never SSRs the page. That path worked, and still works. Only a
**direct hit or a refresh**, which is what someone following a shared link does,
took the SSR path and 500'd. Found by smoke-testing the deployed site
immediately after `frontend-0.2.0` rolled out.

## Alternative considered

Guarding the composable in `login.vue` (`useAuth0() ?? {}`) also stops the
throw, but leaves a server-rendered page whose buttons do nothing until
hydration. `ssr: false` matches what the page actually is.

## Testing

`npm run lint` passes (via lefthook pre-commit). CI covers lint + typecheck +
the production build.

Full local verification was not possible on this machine: `@nuxt/image` pulls
`ipx` as an **optional** dependency, npm skips it on macOS/arm64, and installing
it at the locked `3.1.1` requires compiling `sharp` (needs `node-gyp`). So
`npm run build` fails locally at the prerender step regardless of this change —
the client and server bundles both build fine. Linux CI installs the optional
dep normally, which is why the `0.2.0` release built there without issue.
Verification is therefore against the deployed site once this releases; the
rollback is a one-line revert that Flux applies within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
