### PR TITLE
Deploy: point biosim-gke at frontend-0.2.1

### DIFF
--- a/kustomize/overlays/biosim-gke/kustomization.yaml
+++ b/kustomize/overlays/biosim-gke/kustomization.yaml
@@ -9,7 +9,7 @@ images:
 - name: ghcr.io/biosimulations/platform-worker
   newTag: backend-0.10.0
 - name: ghcr.io/biosimulations/platform-frontend
-  newTag: frontend-0.2.0
+  newTag: frontend-0.2.1
 - name: docker.io/library/mongo
   newTag: 8.0.4
 


### PR DESCRIPTION
Points the `biosim-gke` overlay at `frontend-0.2.1`, deploying the `/login` SSR fix from #101.

Merging this is the deploy — Flux reconciles the overlay within a minute. Backend stays at `backend-0.10.0`.

The `frontend-v0.2.1` release run succeeded (frontend build + Release jobs green) before this was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
