### PR TITLE
Document the GitOps deploy process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: release
 
 # Builds and pushes service images to GHCR, and (on tag pushes) cuts a GitHub
-# Release. Deploy to clusters stays a manual `kubectl apply` step — see
-# backend/CLAUDE.md "Deploy".
+# Release. This workflow publishes images only — it does not deploy them.
+#
+# biosim-gke is reconciled by Flux CD, so deploying is a second PR that bumps
+# the image tag in kustomize/overlays/biosim-gke/. Wait for this workflow to
+# succeed before merging that PR: a failed push still leaves the git tag and
+# the Release behind, and api runs strategy: Recreate at one replica, so an
+# unpublished tag takes the API down. biosim-rke and biosim-local are applied
+# by hand. See backend/CLAUDE.md "Deploy".
 #
 # Triggers:
 #   - Push a version tag:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ This script is the **local / multi-arch fallback**. The normal path is the `rele
 
 ## Release automation
 
-`.github/workflows/release.yaml` builds + pushes images to GHCR and cuts a GitHub Release. **amd64-only.** Deploy to clusters stays a manual `kubectl apply` (see `backend/CLAUDE.md` → Deploy).
+`.github/workflows/release.yaml` builds + pushes images to GHCR and cuts a GitHub Release. **amd64-only.** It publishes images; it does not deploy them — see **Deploy (GitOps)** below.
 
 | Trigger | Builds | Image tag(s) | Release? |
 |---|---|---|---|
@@ -69,6 +69,23 @@ This script is the **local / multi-arch fallback**. The normal path is the `rele
 | `workflow_dispatch` (service + version inputs) | per input | per input | no |
 
 The git tag carries the `v`; the image tag strips it. A `plan` job guards that the tag's version matches the source version file(s) before any build runs. `workflow_dispatch` publishes images only (no Release) — use it for ad-hoc/re-builds.
+
+## Deploy (GitOps)
+
+**`biosim-gke` is reconciled by Flux CD: merging a change to `kustomize/overlays/biosim-gke/` on `main` is the deploy.** Flux polls this repo every minute and applies the overlay, so `kubectl apply` against that namespace is wrong — it gets reverted on the next reconcile. Flux itself is configured in the private `UCHHPC/k8s-config` repo under `gke/fluxcd/`; that README covers install, suspend/resume, and troubleshooting.
+
+`biosim-rke` and `biosim-local` are **not** under Flux — they are still applied by hand.
+
+Releasing and deploying are now **two separate PRs**, in this order:
+
+1. **Release PR** — bump the version file(s) only (`backend/scripts/bump-backend.sh`, `frontend/scripts/bump-frontend.sh`). Merge.
+2. **Tag the merge commit on `main`** and push it — this triggers `release.yaml`. The bump scripts tag the *branch* commit, so re-tag `main`.
+3. **Verify the images published.** The release run's job conclusion is the only reliable gate: the GHCR packages are private (anonymous manifest checks 403 regardless), and a failed push still leaves the git tag and GitHub Release behind.
+4. **Deploy PR** — bump `newTag` in the overlay. Merging deploys it.
+
+> **Do not merge step 4 before step 3 passes.** `api` runs `strategy: Recreate` at one replica, so an unpublished tag takes the API down rather than leaving old pods serving.
+
+Per-service specifics — including the Temporal worker-drain requirement and how it interacts with `flux suspend` — are in `backend/CLAUDE.md` → Deploy and `frontend/CLAUDE.md` → Deploy.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ bash kustomize/scripts/build_and_push.sh frontend
 # Coordinated full release — both services at the same version
 bash kustomize/scripts/build_and_push.sh all 0.5.0
 
-# Apply an overlay
+# Apply an overlay that is NOT under GitOps (biosim-rke, biosim-local)
 export KUBECONFIG=<path-to-kubeconfig>
-kubectl kustomize kustomize/overlays/biosim-gke | kubectl apply -f -
+kubectl kustomize kustomize/overlays/biosim-rke | kubectl apply -f -
 ```
+
+**Deploying to `biosim-gke` is a git commit, not a `kubectl apply`.** That overlay is reconciled by Flux CD from `main`, so bumping an image tag in `kustomize/overlays/biosim-gke/kustomization.yaml` and merging it deploys within a minute; anything applied by hand is reverted on the next reconcile. Publish the image first — `api` runs `strategy: Recreate` at one replica, so an unpublished tag takes the API down. Full procedure in [`backend/CLAUDE.md`](./backend/CLAUDE.md) → Deploy and [`frontend/CLAUDE.md`](./frontend/CLAUDE.md) → Deploy.
 
 ## License
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -238,7 +238,22 @@ pytest -m "not integration"
 
 ## Deploy
 
-Backend release steps (run from repo root unless noted):
+**`biosim-gke` is GitOps-managed by Flux CD — merging a commit is the deploy.**
+Flux watches this repo's `main` and reconciles `kustomize/overlays/biosim-gke`
+into the cluster, so `kubectl apply` there is wrong: it would be reverted on the
+next reconcile. Flux's own config lives in `UCHHPC/k8s-config` under
+`gke/fluxcd/` (that repo's README covers install and day-2 operations).
+
+The other overlays (`biosim-rke`, `biosim-local`) are **not** under Flux and are
+still applied by hand.
+
+> **Never merge an overlay bump before the image is published.** `api` uses
+> `strategy: Recreate` at one replica, so pointing the overlay at a tag that
+> doesn't exist in GHCR tears down the running pod and takes the API down —
+> there is no old pod left serving. (`frontend` is a RollingUpdate at 2
+> replicas and degrades gracefully by comparison.) A release build that fails
+> its GHCR push leaves the git tag and the GitHub Release in place, so neither
+> is proof the image exists — check the release run's job conclusion.
 
 > **Workflow-restructuring releases require a worker drain.** A release that
 > changes the activity sequence inside a Temporal workflow (e.g. PR #52, which
@@ -252,40 +267,71 @@ Backend release steps (run from repo root unless noted):
 > / `query_workflow`. See `docs/workflows-architecture.md` → "Deploy
 > considerations" for the full rationale and the longer-term `workflow.patched`
 > pattern.
+>
+> Under Flux this needs an extra step, since merging the overlay bump would
+> otherwise roll the worker immediately: `flux suspend kustomization
+> platform-biosim-gke` before merging, drain, then `flux resume`.
 
-1. **Bump version + tag** (bumps `version.py` + `pyproject.toml`, commits, tags `backend-vX.Y.Z`):
+Release steps (run from repo root unless noted). **Two PRs, in this order** —
+the release and the deploy are no longer one commit:
+
+1. **Release PR — bump the version only.** The script updates `version.py`,
+   `pyproject.toml`, and the `uv.lock` entry, then commits and tags:
    ```bash
    bash backend/scripts/bump-backend.sh patch      # or minor|major|X.Y.Z
    ```
-2. **Update kustomize overlays** — set `newTag: backend-X.Y.Z` in each overlay's `kustomization.yaml`:
-   - `kustomize/overlays/biosim-gke/kustomization.yaml`
-   - `kustomize/overlays/biosim-rke/kustomization.yaml`
-   - `kustomize/overlays/biosim-local/kustomization.yaml` (see arm64 note below)
-
-   Commit these alongside the bump (the script commits only the version files).
-3. **Push the branch + tag** to build and publish images via CI:
+   It tags the **branch** commit, so delete that tag (`git tag -d
+   backend-vX.Y.Z`) and re-tag the merge commit on `main` in the next step.
+   Open the PR with just the version files; leave the overlays alone for now.
+2. **Tag `main` and push** once the PR is merged:
    ```bash
-   git push origin <branch>
+   git tag backend-vX.Y.Z <merge-commit-sha>
    git push origin backend-vX.Y.Z
    ```
    The `release` workflow (`.github/workflows/release.yaml`) builds + pushes
    `platform-{api,worker}:backend-X.Y.Z` to GHCR (**amd64-only**) and cuts a
-   GitHub Release. Watch it under the repo's Actions tab.
+   GitHub Release. A `plan` job first checks the tag matches `version.py`.
 
    > **arm64 / `biosim-local`:** CI publishes amd64 only. If you need an arm64
    > layer at `backend-X.Y.Z` (e.g. for the `biosim-local` overlay on Apple
    > silicon), build it locally instead: `bash kustomize/scripts/build_and_push.sh backend X.Y.Z`
    > (multi-arch). Or keep `biosim-local` pinned to an older multi-arch tag.
-4. **Apply to cluster** (example for biosim-gke) once images are published:
+3. **Verify the images published.** The job conclusion is the gate:
+   ```bash
+   gh run list --workflow release.yaml --limit 1
+   ```
+   The GHCR packages are private, so an anonymous manifest check returns 403
+   for published and missing tags alike and proves nothing.
+4. **Deploy PR — bump `newTag: backend-X.Y.Z`** in each overlay you're
+   deploying:
+   - `kustomize/overlays/biosim-gke/kustomization.yaml` — **merging is the
+     deploy**; Flux applies it within a minute
+   - `kustomize/overlays/biosim-rke/kustomization.yaml` — apply by hand
+   - `kustomize/overlays/biosim-local/kustomization.yaml` — apply by hand
+
+   Edit the `newTag` lines directly; `kustomize edit set image` reorders the
+   whole block and adds redundant `newName` entries.
+5. **Verify.** For biosim-gke:
    ```bash
    export KUBECONFIG=<path-to-kubeconfig>
-   cd kustomize/overlays/biosim-gke
-   kubectl kustomize . | kubectl apply -f -
+   flux get kustomizations -A                              # READY=True at the new revision
+   kubectl -n biosim-gke rollout status deploy/api
+   curl -s https://api.biosim.biosimulations.org/version
    ```
-5. **Verify**:
+   To skip the poll interval: `flux reconcile kustomization platform-biosim-gke --with-source`.
+
+   For the hand-applied overlays:
    ```bash
-   kubectl get pods -n biosim-gke
+   export KUBECONFIG=<path-to-kubeconfig>
+   kubectl kustomize kustomize/overlays/biosim-rke | kubectl apply -f -
+   kubectl get pods -n biosim-rke
    ```
+
+**Rollback (biosim-gke):** revert the deploy commit on `main`. Flux restores the
+previous state on the next reconcile. For an urgent hand-patch, `flux suspend
+kustomization platform-biosim-gke` first — anything applied by hand while it is
+running gets reverted, and anything applied while suspended gets reverted at
+`flux resume` unless it is also committed.
 
 ## Important Notes
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -132,16 +132,62 @@ The workflow lives at `.github/workflows/frontend-ci.yaml` (repo root) and is pa
 
 ## Deploy
 
-**In progress on `frontend-backend-int`.** Plan: `docs/frontend-backend-integration-plan.md`. Decisions made: independent version streams (frontend at `0.1.0`, tagged `frontend-vX.Y.Z`), runtime-only Dockerfile (build outside Docker, image just runs `node .output/server/index.mjs`), shared Ingress with subdomain split, separate `frontend-dev` namespace on RKE for the frontend dev's branch deploys.
+Shipped and in production. The frontend versions independently of the backend
+(`frontend/package.json` → tag `frontend-vX.Y.Z` → image
+`ghcr.io/biosimulations/platform-frontend:frontend-X.Y.Z`). `frontend/Dockerfile`
+is runtime-only — CI runs `npm ci && npm run build` on the host and the image
+just runs `node .output/server/index.mjs`. Served at
+`biosim.biosimulations.org`, with `api.biosim.biosimulations.org` for the
+backend; SSR fetches inside the cluster use `NUXT_API_URL=http://api:8000` to
+skip the public ingress.
 
-As of writing, still TBD: `frontend/Dockerfile`, `kustomize/base/frontend/` sub-package, `kustomize/scripts/build_and_push.sh frontend`, frontend image registry choice (GHCR vs. dockerhub).
+**`biosim-gke` is GitOps-managed by Flux CD — merging a commit is the deploy.**
+Flux reconciles `kustomize/overlays/biosim-gke` from `main` every minute, so
+`kubectl apply` against that namespace gets reverted. Releasing is **two PRs**:
+
+1. **Release PR** — bump the version. `scripts/bump-frontend.sh` is
+   **patch-only**; for a minor/major run `npm version minor --no-git-tag-version`
+   and commit `package.json` + `package-lock.json` yourself. Merge.
+2. **Tag the merge commit on `main`** and push (`frontend-vX.Y.Z`) — this
+   triggers `.github/workflows/release.yaml`, which builds the image (Node 24,
+   amd64) and cuts a GitHub Release. The bump script tags the *branch* commit,
+   so re-tag `main`.
+3. **Verify the image published** — the release run's job conclusion is the
+   gate. The GHCR package is private, so anonymous manifest checks return 403
+   whether or not the tag exists, and a failed push still leaves the git tag and
+   the Release behind. This exact failure silently stranded `frontend-0.1.1` for
+   three weeks.
+4. **Deploy PR** — bump `newTag: frontend-X.Y.Z` in
+   `kustomize/overlays/biosim-gke/kustomization.yaml`. Merging deploys it.
+   Edit the line directly rather than using `kustomize edit set image`, which
+   reorders the block.
+
+Verify with `flux get kustomizations -A` (READY=True at the new revision) and
+`kubectl -n biosim-gke rollout status deploy/frontend`; `flux reconcile
+kustomization platform-biosim-gke --with-source` skips the poll interval. To
+roll back, revert the deploy commit — Flux restores the previous state within a
+minute.
+
+`kustomize/overlays/biosim-rke-frontend-dev/` (namespace `frontend-dev` on RKE,
+`biosim-dev.cam.uchc.edu`) is **not** under Flux and is applied by hand. It
+points at the RKE backend, and exists for WIP previews and catching
+production-build SSR bugs that `npm run dev` hides — not for personal iteration.
+
+> **SSR is where deploy-only frontend bugs live.** `/login` shipped a 500 in
+> `frontend-0.2.0` because `plugins/auth0.client.ts` is client-only, so
+> `useAuth0()` is undefined during SSR and `login.vue`'s top-level destructure
+> threw. In-app navigation never SSRs a page, so it looked fine everywhere
+> except a direct hit or refresh. Fixed by `'/login': { ssr: false }` in
+> `routeRules`. After any deploy, curl the affected routes directly rather than
+> clicking through the app.
 
 ## Important Notes
 
-1. **Node version matters** — several deps (notably oxc-parser native bindings) require Node 22+. On older Node, `npm install` silently skips optional platform bindings and `nuxt prepare` fails on `require()` of bindings. Use `nvm install 22 && nvm use 22` if needed.
-2. **No `frontend/Dockerfile`** — see Deploy section above.
-3. **Pre-existing lint/typecheck failures** — frontend CI was off in the monorepo until Phase 2 of the integration plan moved the workflow to `.github/workflows/frontend-ci.yaml`. By then ~1500 lint errors and several TS errors had accumulated. Expect `npm run lint` and `npm run typecheck` to fail on `main` until cleanup. Cleanup is its own task.
-4. **README is project-specific** — `frontend/README.md` was replaced with a project-specific quickstart on `frontend-backend-int`; the original Nuxt starter README is gone.
+1. **Node version matters** — several deps (notably oxc-parser native bindings) require Node 22+. On older Node, `npm install` silently skips optional platform bindings and `nuxt prepare` fails on `require()` of bindings. Use `nvm install 22 && nvm use 22` if needed. CI and the release image build on Node 24.
+2. **`npm run build` may not complete on macOS/arm64.** `@nuxt/image` pulls `ipx` as an **optional** dependency (`ipx@3.1.1` in `package-lock.json`), npm skips it there, and the build then dies at the prerender step — which exists only because of `'/': { prerender: true }` in `routeRules` — with `Cannot find package 'ipx'`. Installing it by hand is a trap: a newer major breaks on `createIPXH3Handler`, and the locked version needs `node-gyp` to compile `sharp`. Linux CI installs the optional dep normally, so this is a local-environment limit, not a code problem — verify with `npm run dev` (port 4200, no prerender) or let CI build it. A mismatched `ipx` in `node_modules` breaks the dev server too; `rm -rf node_modules/ipx` to recover.
+3. **`frontend/Dockerfile` is runtime-only** — the Nuxt build happens on the host (`npm ci && npm run build`) and the image just runs `node .output/server/index.mjs` over `.output`. Building the image without a fresh `.output` ships stale code. See Deploy above.
+4. **Pre-existing lint/typecheck failures** — frontend CI was off in the monorepo until Phase 2 of the integration plan moved the workflow to `.github/workflows/frontend-ci.yaml`. By then ~1500 lint errors and several TS errors had accumulated. Expect `npm run lint` and `npm run typecheck` to fail on `main` until cleanup. Cleanup is its own task.
+5. **README is project-specific** — `frontend/README.md` was replaced with a project-specific quickstart on `frontend-backend-int`; the original Nuxt starter README is gone.
 
 ## External Services
 


### PR DESCRIPTION
## Summary

Every guide still described deploying `biosim-gke` with `kubectl apply`. Flux CD has reconciled that overlay since 2026-08-17, so those instructions are now actively wrong — a hand-applied change is reverted on the next reconcile. This rewrites the deploy docs around what actually happens.

| File | Change |
|---|---|
| `CLAUDE.md` | New **Deploy (GitOps)** section; the release-automation blurb no longer claims deploys are manual |
| `backend/CLAUDE.md` | Deploy section rewritten around the two-PR flow |
| `frontend/CLAUDE.md` | Deploy section rewritten (it still described the integration as in progress on a branch merged in May) |
| `README.md` | The "apply an overlay" snippet now targets `biosim-rke`, which really is hand-applied, and points at the GitOps path for `biosim-gke` |
| `.github/workflows/release.yaml` | Header comment corrected |

## The substantive parts

Beyond "Flux does it now", the docs now record what this switch surfaced:

- **Releasing and deploying are two PRs, in order** — bump, tag, *verify the image published*, and only then bump the overlay. They used to ride in one commit (#86, #87), which is unsafe now that merging deploys.
- **Verifying the image is not optional.** `api` runs `strategy: Recreate` at one replica, so an unpublished tag tears down the running pod rather than leaving the old one serving. A failed GHCR push still leaves the git tag and the GitHub Release behind, so neither proves the image exists — this is exactly how `frontend-0.1.1` sat stranded for three weeks. The release run's job conclusion is the gate; the packages are private, so anonymous manifest checks 403 whether or not the tag exists.
- **The Temporal worker-drain requirement now needs `flux suspend` first**, since merging would otherwise roll the worker immediately.
- **Rollback is a revert**, and hand-patching requires suspend/resume.

## Also corrected

- `frontend/Dockerfile` exists and is runtime-only (consumes a host-built `.output`) — the notes said it was still TBD.
- The `/login` SSR 500 is recorded as a worked example of a bug only a deployed direct hit reveals, with the advice to curl routes directly after a deploy rather than clicking through the app.
- The macOS `ipx`/`sharp` limitation that stops `npm run build` from completing locally, so the next person does not spend the time I did on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
