### PR TITLE
Stop prerendering /, which baked empty runtime config into the landing page

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -48,7 +48,15 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
-    '/': { prerender: true },
+    // NOT prerendered. Prerendering runs at build time, where every
+    // NUXT_PUBLIC_* value is absent -- they are supplied at runtime from the
+    // deployment's ConfigMap -- so the generated HTML baked `api_url: ""`,
+    // `auth0Domain: ""`, and so on into its payload. The client then read
+    // those empties for the whole session, sending Log In to
+    // `https://authorize/?client_id=` and any API call to a relative URL on
+    // the frontend's own host. Runtime-configured public values and
+    // prerendering are fundamentally incompatible; the landing page is now
+    // server-rendered per request like every other route.
     '/projects': { redirect: '/biosim-db' },
     '/runs': { redirect: '/simulations' },
     // Client-only. The Auth0 SDK is installed by plugins/auth0.client.ts, which

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platform-frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth0/auth0-vue": "^2.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Clicking **Log In** from the landing page sent users to:

```
https://authorize/?client_id=&scope=openid+profile+email&audience=&...
```

— empty Auth0 domain, client id, and audience. The values are set correctly in
the `biosim-gke` ConfigMap and reach every other route. The landing page is the
only one that never sees them.

`'/': { prerender: true }` renders that page **at build time, in CI**, where no
`NUXT_PUBLIC_*` variable exists — they are supplied at runtime, per deployment.
So the generated HTML baked the build-time defaults into its payload:

| Route | `public` config in the served HTML |
|---|---|
| `/` (prerendered) | `base_url:"" api_url:"" biosimulations_api_url:"" legacy_api_url:"" auth0Domain:"" auth0ClientId:"" auth0Audience:""` |
| `/simulations`, `/login`, everything else | `base_url:"https://biosim.biosimulations.org" api_url:"https://api.biosim.biosimulations.org" … auth0Domain:"dev-bu7yo7484tyxu6a1.us.auth0.com" …` |

Prerendering and runtime-supplied public config cannot coexist. The only way to
keep the rule would be baking environment values into the image at build time —
exactly what the ConfigMap indirection exists to avoid.

## Scope: bigger than the login button

**This is not a new regression.** The rule predates the auth work, so the
landing page has been serving `api_url:""` since the first GKE deploy; the Auth0
values are simply the newest empties to become visible.

It is also **session-wide, not click-wide**. Nuxt's client reads
`useRuntimeConfig()` from the initial document payload, so a visitor who lands
on `/` and then navigates in-app carries the empties for the rest of the
session, issuing API calls to relative URLs on the frontend's own host. That is
the same shape as the project-detail 404s that `NUXT_PUBLIC_LEGACY_API_URL` was
patched around.

## Tradeoff

The landing page is now server-rendered per request like every other route —
marginally slower TTFB, no other behavior change. `/login`'s `ssr: false` rule is
untouched (verified not implicated: the shell it serves carries the correct
runtime values).

## Testing

- `npm run build` — `.output/public/index.html` is **no longer emitted**, so the
  page is served by Nitro per request rather than as a static file with baked
  config.
- `npm run lint` passes (lefthook pre-commit).
- Booting the production bundle locally is still impossible on macOS (the
  runtime needs the optional `ipx` dep, which cannot install here), so the
  end-to-end check is against the deployed site after release. Notably, removing
  this rule **fixes `npm run build` locally** — prerendering was what dragged
  `ipx` into the build at all.

Bumps frontend to **0.2.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
