### PR TITLE
Deploy: point biosim-gke at frontend-0.2.2

### DIFF
--- a/kustomize/overlays/biosim-gke/kustomization.yaml
+++ b/kustomize/overlays/biosim-gke/kustomization.yaml
@@ -9,7 +9,7 @@ images:
 - name: ghcr.io/biosimulations/platform-worker
   newTag: backend-0.10.0
 - name: ghcr.io/biosimulations/platform-frontend
-  newTag: frontend-0.2.1
+  newTag: frontend-0.2.2
 - name: docker.io/library/mongo
   newTag: 8.0.4
 


### PR DESCRIPTION
Points the `biosim-gke` overlay at `frontend-0.2.2`, deploying the prerender fix from #104.

Merging this is the deploy — Flux reconciles within a minute. The `frontend-v0.2.2` release run succeeded before this was opened.

After this lands, `/` should serve real values in its `public` config block (`auth0Domain`, `api_url`, …) instead of empty strings, and Log In from the landing page should redirect to the real Auth0 tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfRrxjsddsBLcFeNCXSBcU
